### PR TITLE
AAP-22019: Operator: Support configuration for either 'WCA Cloud' or 'WCA on-prem'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.3
+VERSION ?= 0.0.4
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/config/crd/bases/aiconnect.ansible.com_ansibleaiconnects.yaml
+++ b/config/crd/bases/aiconnect.ansible.com_ansibleaiconnects.yaml
@@ -232,12 +232,14 @@ spec:
                   - inference_url
                   - model_mesh_api_key
                   - model_mesh_model_name
+                  - model_mesh_type
                 properties:
                   wca_secret_name:
                     description: "Secret where the IBM watsonX Code Assistant configuration can be found. If not specified this secret will be generated."
                     type: string
                   username:
                     description: IBM watsonX Code Assistant username
+                    default: "username"
                     type: string
                   inference_url:
                     description: IBM watsonX Code Assistant endpoint
@@ -248,6 +250,13 @@ spec:
                   model_mesh_model_name:
                     description: IBM watsonX Code Assistant Model Name
                     type: string
+                  model_mesh_type:
+                    description: Type of IBM watsonX Code Assistant provider
+                    default: "wca-onprem"
+                    type: string
+                    enum:
+                      - "wca"
+                      - "wca-onprem"
                 type: object
               ai:
                 description: Defines desired state of the resources

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: manstis/aiconnect
-  newTag: 0.0.3
+  newTag: 0.0.4

--- a/config/manifests/bases/ansible-ai-connect-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ansible-ai-connect-operator.clusterserviceversion.yaml
@@ -50,6 +50,7 @@ spec:
         path: wca.username
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:wca.model_mesh_type:wca-onprem
       - displayName: IBM watsonX Code Assistant endpoint
         path: wca.inference_url
         x-descriptors:
@@ -62,6 +63,12 @@ spec:
         path: wca.model_mesh_model_name
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Type of IBM watsonX Code Assistant provider
+        path: wca.model_mesh_type
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:select:wca
+        - urn:alm:descriptor:com.tectonic.ui:select:wca-onprem
       - displayName: Image Pull Policy
         path: image_pull_policy
         x-descriptors:

--- a/roles/ai/defaults/main.yml
+++ b/roles/ai/defaults/main.yml
@@ -81,12 +81,14 @@ _wca:
   # - inference_url
   # - model_mesh_api_key
   # - model_mesh_model_name
+  # - model_mesh_type
   wca_secret_name: ''
   # Explicit parameters to populate Secret if one does not already exist
   username: ''
   inference_url: ''
   model_mesh_api_key: ''
   model_mesh_model_name: ''
+  model_mesh_type: 'wca-onprem'
 # ========================================
 
 

--- a/roles/ai/templates/ai.configmap.yaml.j2
+++ b/roles/ai/templates/ai.configmap.yaml.j2
@@ -18,6 +18,8 @@ data:
   DEPLOYED_REGION: "onprem"
 
   # Always disabled for "on prem"
+  ENABLE_HEALTHCHECK_ATTRIBUTION: "false"
+  ENABLE_HEALTHCHECK_AUTHORIZATION: "false"
   ENABLE_HEALTHCHECK_SECRET_MANAGER: "false"
 
   # Custom user variables

--- a/roles/ai/templates/ai.deployment.yaml.j2
+++ b/roles/ai/templates/ai.deployment.yaml.j2
@@ -141,10 +141,6 @@ spec:
             secretKeyRef:
               name: '{{ __database_secret_name }}'
               key: password
-        - name: ANSIBLE_AI_MODEL_MESH_API_TYPE
-          value: 'wca'
-        - name: WCA_CLIENT_BACKEND_TYPE
-          value: 'wca-onprem-client'
         - name: ANSIBLE_WCA_USERNAME
           valueFrom:
             secretKeyRef:
@@ -173,6 +169,11 @@ spec:
             secretKeyRef:
               name: '{{ __wca_secret_name }}'
               key: model_mesh_model_name
+        - name: ANSIBLE_AI_MODEL_MESH_API_TYPE
+          valueFrom:
+            secretKeyRef:
+              name: '{{ __wca_secret_name }}'
+              key: model_mesh_type
         - name: ANSIBLE_WCA_HEALTHCHECK_API_KEY
           valueFrom:
             secretKeyRef:

--- a/roles/ai/templates/secrets/wca.secret.yaml.j2
+++ b/roles/ai/templates/secrets/wca.secret.yaml.j2
@@ -16,3 +16,4 @@ stringData:
   inference_url: '{{ combined_wca.inference_url }}'
   model_mesh_api_key: '{{ combined_wca.model_mesh_api_key }}'
   model_mesh_model_name: '{{ combined_wca.model_mesh_model_name }}'
+  model_mesh_type: '{{ combined_wca.model_mesh_type }}'


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-22019

The selection between `wcaclient` and `wca-onprem-client` is tucked under the "Advanced" section.

If the User does not specify a type the Operator defaults to `wca-onprem-client`.

**WCA provider type selection - `wcaclient`**

![wca](https://github.com/ansible/ansible-ai-connect-operator/assets/497544/355023d1-5175-44c2-830d-49814c06df64)

**WCA provider type selection - `wca-onprem-client`**

`username` is also shown as it is need for ZenAPI authentication.

![wca-onprem](https://github.com/ansible/ansible-ai-connect-operator/assets/497544/54910e26-2563-4d15-bda4-c616a274417b)
