### PR TITLE
AAP-21787: Lightspeed operator: Deployed Region

### DIFF
--- a/roles/ai/templates/ai.configmap.yaml.j2
+++ b/roles/ai/templates/ai.configmap.yaml.j2
@@ -13,9 +13,9 @@ data:
   ENABLE_ADDITIONAL_CONTEXT: "true"
   DEPLOYMENT_MODE: "onprem"
 
-  # {manstis} Do we want to expose this for customers?
+  # Remove 'deployed_region' from the /status/check endpoint
   # See https://issues.redhat.com/browse/AAP-21787
-  DEPLOYED_REGION: "onprem"
+  DEPLOYED_REGION: ""
 
   # Always disabled for "on prem"
   ENABLE_HEALTHCHECK_ATTRIBUTION: "false"


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-21787

This sets `DEPLOYED_REGION` to an empty string ensuring it is absent from the `/status/check` endpoint.