### PR TITLE
Reduce resource_requirements for CI on sample custom resource

### DIFF
--- a/molecule/default/templates/instance_minikube.yaml.j2
+++ b/molecule/default/templates/instance_minikube.yaml.j2
@@ -25,3 +25,13 @@ spec:
     model_mesh_model_name: 'my-ai-model_name'
   database:
     postgres_storage_class: standard
+  api:
+    resource_requirements:
+      requests:
+        cpu: 100m
+        memory: 200Mi
+  database:
+    resource_requirements:
+      requests:
+        cpu: 50m
+        memory: 100Mi


### PR DESCRIPTION
GHA workers don't have nearly enough memory for the 5Gi default the AI API container requests.  This lowers that by overriding the resource_requirements on the CI sample custom resource.  