### PR TITLE
Clean up molecule-tests.yaml

### DIFF
--- a/.github/workflows/molecule-tests.yaml
+++ b/.github/workflows/molecule-tests.yaml
@@ -1,12 +1,6 @@
 name: Molecule Tests
 on:
   workflow_dispatch:
-    #inputs:
-    #  debug_enabled:
-    #    type: boolean
-    #    description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
-    #    required: false
-    #    default: false
 
 jobs:
   build:
@@ -21,11 +15,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    #- name: Setup tmate session
-    #  uses: mxschmitt/action-tmate@v3
-    #  if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
-
-
     - uses: actions/setup-python@v4
       with:
         python-version: '3.10'
@@ -35,12 +24,6 @@ jobs:
 
     - name: Sleep for 3 minutes
       run: sleep 180
-
-    - name: Run kubectl get pods for debugging
-      run: kubectl -n osdk-test get pods
-
-    - name: Print Operator logs for debugging
-      run: kubectl -n osdk-test logs -f deployments/osdk-controller-manager
 
     - name: Install Dependencies
       run: |


### PR DESCRIPTION
Removing all steps that are causing the workflow to fail before the run molecule command.