### PR TITLE
Update destroy.yaml

### DIFF
--- a/molecule/default/destroy.yml
+++ b/molecule/default/destroy.yml
@@ -10,6 +10,8 @@
     - import_tasks: kustomize.yml
       vars:
         state: absent
+      tags:
+        - always
 
     - name: Destroy Namespace
       k8s:
@@ -17,18 +19,12 @@
         kind: Namespace
         name: '{{ namespace }}'
         state: absent
-
-    - name: Unset testing image
-      command: '{{ kustomize }} edit set image testing=testing-operator'
-      args:
-        chdir: '{{ config_dir }}/testing'
+      tags:
+        - always
 
     - name: Unset pull policy
       command: '{{ kustomize }} edit remove patch --path pull_policy/{{ operator_pull_policy }}.yaml'
       args:
         chdir: '{{ config_dir }}/testing'
-
-    - name: Unset testing namespace
-      command: '{{ kustomize }} edit set namespace osdk-test'
-      args:
-        chdir: '{{ config_dir }}/testing'
+      tags:
+        - always


### PR DESCRIPTION
Removing some of the cases from the destroy.yaml file that could make the prune() to fail.