### PR TITLE
Expose API image container properties.

### DIFF
--- a/config/crd/bases/aiconnect.ansible.com_ansibleaiconnects.yaml
+++ b/config/crd/bases/aiconnect.ansible.com_ansibleaiconnects.yaml
@@ -49,15 +49,15 @@ spec:
                   - IfNotPresent
                   - ifnotpresent
               image_pull_secrets:
-                description: Image pull secrets for app and database containers
+                description: Image pull secrets for the API and database containers
                 type: array
                 items:
                   type: string
               image:
-                description: Registry path to AI container image to use
+                description: Registry path to API container image to use
                 type: string
               image_version:
-                description: AI container image tag or version to use
+                description: API container image tag or version to use
                 type: string
               additional_labels:
                 description: Additional labels defined on the resource, which should be propagated to child resources

--- a/config/manifests/bases/ansible-ai-connect-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ansible-ai-connect-operator.clusterserviceversion.yaml
@@ -79,16 +79,14 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
-      - displayName: AI Image
+      - displayName: API container image
         path: image
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - displayName: AI Image Version
+      - displayName: API container image Version
         path: image_version
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Additional labels defined on the resource, which should be propagated
           to child resources
         path: additional_labels


### PR DESCRIPTION
Following the discussion in today's "onprem" status meeting.

This PR makes the "Image" and "Image version" properties visible in OLM's UI.

It also renames them slightly to align with other references.