### PR TITLE
Set database storage class for minikube

### DIFF
--- a/molecule/default/templates/instance_minikube.yaml.j2
+++ b/molecule/default/templates/instance_minikube.yaml.j2
@@ -31,6 +31,7 @@ spec:
         cpu: 100m
         memory: 200Mi
   database:
+    postgres_storage_class: standard
     resource_requirements:
       requests:
         cpu: 50m


### PR DESCRIPTION
The _managed_ Postgres instance failed to be provision. 

Lets ensure the `postgres_storage_class` is set.

IDK why it _appears_ to run OK locally. 