### PR TITLE
Minikube storage addons..

### DIFF
--- a/.github/workflows/molecule-tests.yaml
+++ b/.github/workflows/molecule-tests.yaml
@@ -21,6 +21,8 @@ jobs:
 
     - name: Start minikube
       uses: medyagh/setup-minikube@latest
+      with:
+        addons: storage-provisioner,default-storageclass
 
     - name: Sleep for 3 minutes
       run: sleep 180


### PR DESCRIPTION
Local `minikube` includes the storage addons..

The GHA action to start `minikube` [does not](https://github.com/medyagh/setup-minikube?tab=readme-ov-file#configurable-fields) (see `addons`->`default: ''`)