### PR TITLE
Move operator version to variable.

### DIFF
--- a/.github/workflows/molecule-tests.yaml
+++ b/.github/workflows/molecule-tests.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKER_CONFIG_JSON: ${{ secrets.TESTING_DOCKER_CONFIG_JSON }}
-      OPERATOR_IMAGE: quay.io/ansible/ansible-ai-connect-operator:latest
+      OPERATOR_IMAGE: quay.io/ansible/ansible-ai-connect-operator:{{ secrets.TESTING_OPERATOR_VERSION }}
       DOCKER_API_VERSION: "1.41"
 
     steps:


### PR DESCRIPTION
The `latest` version is broken.

This allows us to test with whatever version we choose.

I've created the `Action` variable already and set it to a known working version.

Local `minikube` tests pass with this setting.