### PR TITLE
AAP-21929: Setup a workflow to run Molecule tests

### DIFF
--- a/.github/workflows/molecule-kind-tests.yaml
+++ b/.github/workflows/molecule-kind-tests.yaml
@@ -9,8 +9,9 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     env:
+      OPERATOR_IMAGE: ${{ vars.TESTING_OPERATOR_IMAGE }}
+      OPERATOR_PULL_POLICY: ${{ vars.TESTING_OPERATOR_PULL_POLICY }}
       DOCKER_CONFIG_JSON: ${{ secrets.TESTING_DOCKER_CONFIG_JSON }}
-      OPERATOR_IMAGE: quay.io/ansible/ansible-ai-connect-operator:${{ secrets.TESTING_OPERATOR_VERSION }}
       DOCKER_API_VERSION: "1.41"
 
     steps:

--- a/.github/workflows/molecule-minikube-tests.yaml
+++ b/.github/workflows/molecule-minikube-tests.yaml
@@ -8,8 +8,9 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     env:
+      OPERATOR_IMAGE: ${{ vars.TESTING_OPERATOR_IMAGE }}
+      OPERATOR_PULL_POLICY: ${{ vars.TESTING_OPERATOR_PULL_POLICY }}
       DOCKER_CONFIG_JSON: ${{ secrets.TESTING_DOCKER_CONFIG_JSON }}
-      OPERATOR_IMAGE: quay.io/ansible/ansible-ai-connect-operator:${{ secrets.TESTING_OPERATOR_VERSION }}
       DOCKER_API_VERSION: "1.41"
 
     steps:


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-21929

Externalise the Operator Image and Pull Policy to GitHub variables.