### PR TITLE
AAP-21929: Setup a workflow to run Molecule tests. Bump dependencies.

### DIFF
--- a/.github/workflows/molecule-kind-tests.yaml
+++ b/.github/workflows/molecule-kind-tests.yaml
@@ -24,7 +24,6 @@ jobs:
       - name: Install Dependencies
         run: |
           pip install --upgrade pip
-          pip install ansible==9.3.0
           pip install -r molecule/requirements.txt
 
       - name: Install Collections

--- a/.github/workflows/molecule-minikube-tests.yaml
+++ b/.github/workflows/molecule-minikube-tests.yaml
@@ -32,7 +32,6 @@ jobs:
     - name: Install Dependencies
       run: |
         pip install --upgrade pip
-        pip install ansible==9.3.0
         pip install -r molecule/requirements.txt
 
     - name: Install Collections

--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -1,7 +1,8 @@
-ansible-core
-molecule==6.0.3
+ansible==9.4.0
+ansible-core==2.16.5
+molecule==24.2.0
 kubernetes==29.0.0
 
 # See https://github.com/docker/docker-py/issues/3113
+# See https://github.com/docker/docker-py/pull/3116
 requests<2.29.0
-urllib3<2.0


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-21929

This bumps dependencies to see if it fixes the `minikube` issues.. without breaking `kind`.