### PR TITLE
Increase memory. Failing due to 'Exit Code: 137'.

### DIFF
--- a/.github/workflows/molecule-minikube-tests.yaml
+++ b/.github/workflows/molecule-minikube-tests.yaml
@@ -24,7 +24,7 @@ jobs:
       uses: medyagh/setup-minikube@latest
       with:
         addons: storage-provisioner,default-storageclass
-        memory: 4096
+        memory: 7800
 
     - name: Sleep for 3 minutes
       run: sleep 180


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-21929

The last `minikube` run failed due to:
```
"containerStatuses": [
  {
    "containerID": "...",
    "image": "quay.io/ansible/wisdom-service:latest",
    "imageID": "...",
    "lastState": {
      "terminated": {
        "containerID": "...",
        "exitCode": 137,
        "reason": "Error",
        ...
      }
      ...
    }
    ...
  }
  ...
]
```