### PR TITLE
AAP-22436: Build and push operator bundle and catalog to quay.io. Remove old tag format.

### DIFF
--- a/.github/workflows/build-operator-image.yaml
+++ b/.github/workflows/build-operator-image.yaml
@@ -52,13 +52,13 @@ jobs:
         run: |
           REPO=quay.io/ansible/ansible-ai-connect-operator
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "IMAGE_SEMVER_VERSION=${{ steps.next_tag.outputs.patch }}-pr-${{ github.event.pull_request.number }}.$(date +'%Y%m%d%H%M')" >> $GITHUB_ENV
+            echo "IMAGE_SEMVER_VERSION=${{ steps.next_tag.outputs.patch }}-pr-${{ github.event.pull_request.number }}-$(date +'%Y%m%d%H%M')" >> $GITHUB_ENV
 
           elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "IMAGE_SEMVER_VERSION=${{ steps.next_tag.outputs.patch }}-${{ github.ref_name }}-$( git rev-parse --short HEAD ).$(date +'%Y%m%d%H%M')" >> $GITHUB_ENV
+            echo "IMAGE_SEMVER_VERSION=${{ steps.next_tag.outputs.patch }}-${{ github.ref_name }}-$( git rev-parse --short HEAD )-$(date +'%Y%m%d%H%M')" >> $GITHUB_ENV
 
           else
-            echo "IMAGE_SEMVER_VERSION=${{ steps.next_tag.outputs.patch }}.$(date +'%Y%m%d%H%M')" >> $GITHUB_ENV
+            echo "IMAGE_SEMVER_VERSION=${{ steps.next_tag.outputs.patch }}-$(date +'%Y%m%d%H%M')" >> $GITHUB_ENV
           fi
 
       - name: Tag Name
@@ -66,14 +66,14 @@ jobs:
         run: |
           REPO=quay.io/ansible/ansible-ai-connect-operator
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "IMAGE_TAGS=-t ${REPO}:pr-${{ github.event.pull_request.number }}.$(date +'%Y%m%d%H%M') -t ${REPO}:pr-${{ github.event.pull_request.number }} -t ${REPO}:${IMAGE_SEMVER_VERSION}" >> $GITHUB_OUTPUT
+            echo "IMAGE_TAGS=-t ${REPO}:${IMAGE_SEMVER_VERSION}" >> $GITHUB_OUTPUT
             echo "LABEL quay.expires-after=3d" >> ./Dockerfile # tag expires in 3 days
 
           elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "IMAGE_TAGS=-t ${REPO}:${{ github.ref_name }}-$( git rev-parse --short HEAD ).$(date +'%Y%m%d%H%M') -t ${REPO}:${IMAGE_SEMVER_VERSION}" >> $GITHUB_OUTPUT
+            echo "IMAGE_TAGS=-t ${REPO}:${IMAGE_SEMVER_VERSION}" >> $GITHUB_OUTPUT
 
           else
-            echo "IMAGE_TAGS=-t ${REPO}:latest -t ${REPO}:${IMAGE_SEMVER_VERSION}" >> $GITHUB_OUTPUT
+            echo "IMAGE_TAGS=-t ${REPO}:${IMAGE_SEMVER_VERSION} -t ${REPO}:latest" >> $GITHUB_OUTPUT
           fi
 
       # ===================


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-22436

This PR builds on top of #51 removing the old style tags.

Tags are now:

- Pull Requests: `<semver>-pr-<pr-number>-<timestamp>` 
- Workflow dispatch: `<semver>-<ref-name>-<short-sha>-<timestamp>`
- Others: `<semver>-<timestamp>` and `latest`

Where `<semver>` is the latest tag in GutHub with the _patch_ incremented; for example if the latest tagged [`release`](https://github.com/ansible/ansible-ai-connect-operator/blob/main/.github/workflows/release.yaml) is `0.1.0` the version used in [`build-operator-image`](https://github.com/ansible/ansible-ai-connect-operator/blob/main/.github/workflows/build-operator-image.yaml) will be `0.1.1`. When another [`release`](https://github.com/ansible/ansible-ai-connect-operator/blob/main/.github/workflows/release.yaml) is performed and tagged as `0.2.0` the version used in [`build-operator-image`](https://github.com/ansible/ansible-ai-connect-operator/blob/main/.github/workflows/build-operator-image.yaml) will be `0.2.1` etc.