### PR TITLE
AAP-22910: Pin to wisdom-service quay tag for CI/CD pipeline

### DIFF
--- a/.github/workflows/build-operator-image.yaml
+++ b/.github/workflows/build-operator-image.yaml
@@ -88,7 +88,7 @@ jobs:
       # -------------------
       - name: Build and Store Image @ghcr
         run: |
-          BUILD_ARGS="--build-arg DEFAULT_AI_CONNECT_VERSION=${LATEST_AI_CONNECT_VERSION}" \
+          BUILD_ARGS="--build-arg DEFAULT_AI_CONNECT_VERSION=${LATEST_AI_CONNECT_VERSION} --build-arg OPERATOR_VERSION=${IMAGE_SEMVER_VERSION}" \
           IMG=ghcr.io/${{ github.repository_owner }}/ansible-ai-connect-operator:${{ github.sha }} \
           make docker-buildx
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM quay.io/operator-framework/ansible-operator:v1.32.0
 
+ARG DEFAULT_AI_CONNECT_VERSION
+ARG OPERATOR_VERSION
+
+ENV DEFAULT_AI_CONNECT_VERSION=${DEFAULT_AI_CONNECT_VERSION}
+ENV OPERATOR_VERSION=${OPERATOR_VERSION}
+
 COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
  && chmod -R ug+rwx ${HOME}/.ansible


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-22910

This _should_ read the latest tag from `prod2-west` and use it as the default `wisdom-service` version defined in the Operator.