### PR TITLE
AAP-23115: Updating ModelId of existing AnsibleAIConnect CR won't take effect.

### DIFF
--- a/molecule/default/tasks/1_0_health_check_test.yml
+++ b/molecule/default/tasks/1_0_health_check_test.yml
@@ -1,5 +1,5 @@
 ---
-- include_tasks: create_instance.yml
+- include_tasks: 1_1_create_instance.yml
 
 - block:
     - name: Get API Pod details
@@ -18,7 +18,7 @@
           - app.kubernetes.io/name = ansibleaiconnect-sample
       register: aiconnect_api_service
 
-    - name: Basic Health Check
+    - name: Get Health Check
       uri:
         url: 'http://{{ service_host_ip }}:{{ service_host_port }}/check/'
         return_content: true
@@ -32,4 +32,4 @@
         that:
         - service_host_response.status == 200
         - service_host_response.json.status == 'ok'
-        fail_msg: Service did not return expected response
+        fail_msg: /check endpoint did not return expected response. Expected HTTP200, OK.

--- a/molecule/default/tasks/1_1_create_instance.yml
+++ b/molecule/default/tasks/1_1_create_instance.yml
@@ -3,7 +3,7 @@
   k8s:
     state: present
     namespace: '{{ namespace }}'
-    definition: "{{ lookup('template', 'instance_minikube.yaml.j2') | from_yaml }}"
+    definition: "{{ lookup('template', 'create_instance.yaml.j2') | from_yaml }}"
     apply: true
     wait: yes
     wait_timeout: 900

--- a/molecule/default/tasks/2_0_ai_config_test.yml
+++ b/molecule/default/tasks/2_0_ai_config_test.yml
@@ -1,0 +1,53 @@
+---
+- block:
+    - name: Get API Pod details
+      k8s_info:
+        namespace: '{{ namespace }}'
+        kind: Pod
+        label_selectors:
+          - app.kubernetes.io/name = ansibleaiconnect-sample
+      register: aiconnect_api_pod
+
+    - name: Get API Service details
+      k8s_info:
+        namespace: '{{ namespace }}'
+        kind: Service
+        label_selectors:
+          - app.kubernetes.io/name = ansibleaiconnect-sample
+      register: aiconnect_api_service
+
+    - name: Get original model_name
+      uri:
+        url: 'http://{{ service_host_ip }}:{{ service_host_port }}/check/status/'
+        return_content: true
+      vars:
+        service_host_ip: '{{ aiconnect_api_pod.resources[0].status.hostIP }}'
+        service_host_port: '{{ aiconnect_api_service.resources[0].spec.ports[0].nodePort }}'
+      register: service_host_response
+
+    - name: Assert original model_name response
+      assert:
+        that:
+          - service_host_response.status == 200
+          - service_host_response.json.status == 'ok'
+          - service_host_response.json.model_name == 'my-ai-model_name'
+        fail_msg: /check/status did not return expected model_name. Expected 'my-ai-model_name'.
+
+    - include_tasks: 2_1_update_instance_model_name.yml
+
+    - name: Get updated model_name
+      uri:
+        url: 'http://{{ service_host_ip }}:{{ service_host_port }}/check/status/'
+        return_content: true
+      vars:
+        service_host_ip: '{{ aiconnect_api_pod.resources[0].status.hostIP }}'
+        service_host_port: '{{ aiconnect_api_service.resources[0].spec.ports[0].nodePort }}'
+      register: updated_service_host_response
+
+    - name: Assert updated model_name response
+      assert:
+        that:
+        - updated_service_host_response.status == 200
+        - updated_service_host_response.json.status == 'ok'
+        - updated_service_host_response.json.model_name == 'updated__my-ai-model_name'
+        fail_msg: /check/status did not return expected model_name. Expected 'updated__my-ai-model_name'.

--- a/molecule/default/tasks/2_1_update_instance_model_name.yml
+++ b/molecule/default/tasks/2_1_update_instance_model_name.yml
@@ -1,0 +1,43 @@
+---
+- name: Update aiconnect.ansible.com/v1alpha1.AnsibleAIConnect instance model_name
+  k8s:
+    state: present
+    namespace: '{{ namespace }}'
+    definition: "{{ lookup('template', 'update_instance_model_name.yaml.j2') | from_yaml }}"
+    apply: true
+    wait: yes
+    wait_timeout: 60
+    wait_condition:
+      type: Running
+      reason: Successful
+      status: "True"
+
+- name: Wait for provisioning of the updated API Pod to start
+  k8s_info:
+    kind: Pod
+    api_version: v1
+    label_selectors:
+      - "app.kubernetes.io/component=ansible-ai-connect-api"
+  register: ai_pods
+  until:
+    - "ai_pods['resources'] | length"
+    - "ai_pods['resources'] | length == 2"
+  retries: 20
+  delay: 5
+
+- name: Wait for the updated API Pod to be the only one available
+  k8s_info:
+    kind: Pod
+    api_version: v1
+    label_selectors:
+      - "app.kubernetes.io/component=ansible-ai-connect-api"
+    field_selectors:
+      - status.phase=Running
+  register: ai_pod
+  until:
+    - "ai_pod['resources'] | length"
+    - "ai_pod['resources'] | length == 1"
+    - "ai_pod['resources'][0]['status']['phase'] == 'Running'"
+    - "ai_pod['resources'][0]['status']['containerStatuses'][0]['ready'] == true"
+  retries: 30
+  delay: 5

--- a/molecule/default/templates/create_instance.yaml.j2
+++ b/molecule/default/templates/create_instance.yaml.j2
@@ -40,3 +40,8 @@ spec:
       requests:
         cpu: 50m
         memory: 100Mi
+  extra_settings:
+    - setting: ENABLE_HEALTHCHECK_WCA
+      value: false
+    - setting: ENABLE_HEALTHCHECK_WCA_ONPREM
+      value: false

--- a/molecule/default/templates/update_instance_model_name.yaml.j2
+++ b/molecule/default/templates/update_instance_model_name.yaml.j2
@@ -1,0 +1,47 @@
+apiVersion: aiconnect.ansible.com/v1alpha1
+kind: AnsibleAIConnect
+metadata:
+  labels:
+    app.kubernetes.io/name: ansibleaiconnect
+    app.kubernetes.io/instance: ansibleaiconnect-sample
+    app.kubernetes.io/part-of: ansible-ai-connect-operator
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: ansible-ai-connect-operator
+  name: ansibleaiconnect-sample
+spec:
+  no_log: false
+  ingress_type: Ingress
+  service_type: NodePort
+  image_pull_secrets:
+    - redhat-operators-pull-secret
+{% if wisdom_service_image %}
+  image: {{ wisdom_service_image }}
+{% endif %}
+{% if wisdom_service_version %}
+  image_version: {{ wisdom_service_version }}
+{% endif %}
+  auth:
+    aap_api_url: 'my-aap-api-url'
+    social_auth_aap_key: 'my-aap-key'
+    social_auth_aap_secret: 'my-aap-secret'
+  ai:
+    username: 'username'
+    inference_url: 'http://my-ai-instance/'
+    model_mesh_api_key: 'my-ai-api-key'
+    model_mesh_model_name: 'updated__my-ai-model_name'
+  api:
+    resource_requirements:
+      requests:
+        cpu: 100m
+        memory: 200Mi
+  database:
+    postgres_storage_class: standard
+    resource_requirements:
+      requests:
+        cpu: 50m
+        memory: 100Mi
+  extra_settings:
+    - setting: ENABLE_HEALTHCHECK_WCA
+      value: false
+    - setting: ENABLE_HEALTHCHECK_WCA_ONPREM
+      value: false

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -11,10 +11,11 @@
 
   tasks:
     - block:
-        - name: Import all test files from tasks/
+        - name: Import all test files from tasks
           include_tasks: '{{ item }}'
           with_fileglob:
-            - tasks/health_check_test.yml
+            - tasks/1_0_health_check_test.yml
+            - tasks/2_0_ai_config_test.yml
           tags:
             - always
       rescue:

--- a/roles/ai/tasks/combine_defaults.yml
+++ b/roles/ai/tasks/combine_defaults.yml
@@ -9,11 +9,14 @@
 - name: Display Auth variables
   debug:
     var: combined_auth
+  no_log: "{{ no_log }}"
 
 - name: Display API variables
   debug:
     var: combined_api
+  no_log: "{{ no_log }}"
 
 - name: Display AI variables
   debug:
     var: combined_ai
+  no_log: "{{ no_log }}"

--- a/roles/ai/tasks/set_ai_configuration_secret.yml
+++ b/roles/ai/tasks/set_ai_configuration_secret.yml
@@ -13,19 +13,8 @@
     - ai.ai_secret_name | length
   no_log: "{{ no_log }}"
 
-- name: Check for existing AI configuration
-  k8s_info:
-    kind: Secret
-    namespace: '{{ ansible_operator_meta.namespace }}'
-    name: '{{ ansible_operator_meta.name }}-ai-configuration'
-  register: _existing_ai_config_resources
-  no_log: "{{ no_log }}"
-
-- name: Set AI configuration based on if user secret exists
-  set_fact:
-    _ai_config: '{{ _custom_ai_config_resources["resources"] | default([]) | length | ternary(_custom_ai_config_resources, _existing_ai_config_resources) }}'
-  no_log: "{{ no_log }}"
-
+# Always generate the Secret, if a custom one is not being used, in case any
+# configuration parameter on the AnsibleAIConnect definition has changed.
 - block:
     - name: Create AI configuration
       k8s:
@@ -40,11 +29,11 @@
         name: '{{ ansible_operator_meta.name }}-ai-configuration'
       register: _generated_ai_config_resources
       no_log: "{{ no_log }}"
-  when: not _ai_config['resources'] | default([]) | length
+  when: not _custom_ai_config_resources['resources'] | default([]) | length
 
 - name: Set AI Configuration
   set_fact:
-    ai_config: '{{ _generated_ai_config_resources["resources"] | default([]) | length | ternary(_generated_ai_config_resources, _ai_config) }}'
+    ai_config: '{{ _generated_ai_config_resources["resources"] | default([]) | length | ternary(_generated_ai_config_resources, _custom_ai_config_resources) }}'
   no_log: "{{ no_log }}"
 
 - name: Set actual AI configuration secret used

--- a/roles/ai/tasks/set_auth_configuration_secret.yml
+++ b/roles/ai/tasks/set_auth_configuration_secret.yml
@@ -13,19 +13,8 @@
     - auth.auth_secret_name | length
   no_log: "{{ no_log }}"
 
-- name: Check for existing Authentication configuration
-  k8s_info:
-    kind: Secret
-    namespace: '{{ ansible_operator_meta.namespace }}'
-    name: '{{ ansible_operator_meta.name }}-auth-configuration'
-  register: _existing_auth_config_resources
-  no_log: "{{ no_log }}"
-
-- name: Set Authentication configuration based on if user secret exists
-  set_fact:
-    _auth_config: '{{ _custom_auth_config_resources["resources"] | default([]) | length | ternary(_custom_auth_config_resources, _existing_auth_config_resources) }}'
-  no_log: "{{ no_log }}"
-
+# Always generate the Secret, if a custom one is not being used, in case any
+# configuration parameter on the AnsibleAIConnect definition has changed.
 - block:
     - name: Create Authentication configuration
       k8s:
@@ -40,11 +29,11 @@
         name: '{{ ansible_operator_meta.name }}-auth-configuration'
       register: _generated_auth_config_resources
       no_log: "{{ no_log }}"
-  when: not _auth_config['resources'] | default([]) | length
+  when: not _custom_auth_config_resources['resources'] | default([]) | length
 
 - name: Set Authentication Configuration
   set_fact:
-    auth_config: '{{ _generated_auth_config_resources["resources"] | default([]) | length | ternary(_generated_auth_config_resources, _auth_config) }}'
+    auth_config: '{{ _generated_auth_config_resources["resources"] | default([]) | length | ternary(_generated_auth_config_resources, _custom_auth_config_resources) }}'
   no_log: "{{ no_log }}"
 
 - name: Set actual Authentication configuration secret used

--- a/roles/ai/templates/ai.deployment.yaml.j2
+++ b/roles/ai/templates/ai.deployment.yaml.j2
@@ -34,6 +34,19 @@ spec:
         app.kubernetes.io/component: '{{ deployment_type }}-api'
       annotations:
         kubectl.kubernetes.io/default-container: 'ai-api'
+{% for template in [
+    "ai.configmap",
+    "ai.configmap.wisdom-service",
+    "secrets/ai.secret",
+    "secrets/auth.secret",
+  ] %}
+        checksum-{{ template | replace('/', '-') }}: "{{ lookup('template', template + '.yaml.j2') | sha1 }}"
+{% endfor %}
+{% for secret in [
+    "secrets/db_fields_encryption",
+  ] %}
+        checksum-secret-{{ secret }}: "{{ lookup('ansible.builtin.vars', secret, default='')["resources"][0]["data"] | default('') | sha1 }}"
+{% endfor %}
     spec:
       serviceAccountName: '{{ ansible_operator_meta.name }}'
 {% if image_pull_secrets | length > 0 %}


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-23115

This PR fixes changes to parameters within either the `ai` or `auth` blocks.

It also includes a (unit) test for the `model_name` change.