### PR TITLE
Bug in release workflow: should be the tag, not `main`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          ref: 'main'
+          # ref: 'main'
           depth: 0
           path: ansible-ai-connect-operator
 


### PR DESCRIPTION
If the following happens:

1. When the `stage.yaml` is run, it creates a tag from the tip of `main`
2. an other PR is merged
3. now come to trigger the `release.yaml`, it is checking out `main` which is different from step 1.  The operator image is fine because it was built in step 1.  but the bundle and catalog is built based on a new `main` which is different from the operator.

Other than that, I wonder why we are not building all 3 at the same time, either in step 1 or in step 3.
