### PR TITLE
Push 'latest' tag to repository as well

### DIFF
--- a/.github/workflows/build-operator-image.yaml
+++ b/.github/workflows/build-operator-image.yaml
@@ -103,7 +103,7 @@ jobs:
       - name: Build Bundle Image
         run: |
           make bundle bundle-build VERSION=${IMAGE_SEMVER_VERSION} IMG=quay.io/ansible/ansible-ai-connect-operator:${IMAGE_SEMVER_VERSION} BUNDLE_IMG=ansible-ai-connect-bundle:${IMAGE_SEMVER_VERSION}
-          docker tag  ansible-ai-connect-bundle:${IMAGE_SEMVER_VERSION} ansible-ai-connect-bundle:latest
+          docker tag ansible-ai-connect-bundle:${IMAGE_SEMVER_VERSION} ansible-ai-connect-bundle:latest
 
       - name: Push Bundle Image
         uses: redhat-actions/push-to-registry@v2.7.1
@@ -121,7 +121,7 @@ jobs:
       - name: Build Catalog Image
         run: |
           make catalog-build CATALOG_IMG=ansible-ai-connect-catalog:${IMAGE_SEMVER_VERSION} BUNDLE_IMG=quay.io/ansible/ansible-ai-connect-bundle:${IMAGE_SEMVER_VERSION}
-          docker tag  ansible-ai-connect-catalog:${IMAGE_SEMVER_VERSION} ansible-ai-connect-catalog:latest
+          docker tag ansible-ai-connect-catalog:${IMAGE_SEMVER_VERSION} ansible-ai-connect-catalog:latest
 
       - name: Push Catalog Image
         uses: redhat-actions/push-to-registry@v2.7.1


### PR DESCRIPTION
Hey @jameswnl  , just a proposal for getting things "less" complex for on-prem...

Trying push the `latest` tag for both images and then `argoCD updater` will just look for it. 

PS: The `push-to-registry` plugin allows to push multiple tags, see [documentation](https://github.com/redhat-actions/push-to-registry#image-tag-inputs)

Doesn't depend on any other PR, but it is expecting to be **followed by** https://github.com/ansible/ansible-wisdom-ops/pull/798