### PR TITLE
Do not build inmages for PRs

### DIFF
--- a/.github/workflows/build-operator-image.yaml
+++ b/.github/workflows/build-operator-image.yaml
@@ -5,9 +5,6 @@ name: Build Operator Image
 on:
   push:
     branches: [main]
-  pull_request:
-    branches:
-      - main
 
 jobs:
   release:


### PR DESCRIPTION
@jameswnl  @manstis 

This PR prevents from pushing image tag on the PRs. This way, even if we push the `latest` tag, it will never override the "real" tags from the regular builds.

Another option if you want to preserve PRs image builds, but not for pushing the `latest`, in case this PR https://github.com/ansible/ansible-ai-connect-operator/pull/84 applies, is refactoring the PR in a new workflow file, so the tags will be pushed on every PR except the `latest`. Let me know what you prefer, please