### PR TITLE
AAP-23185: Closed-beta preparation - snyk scanning - version updates.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM quay.io/operator-framework/ansible-operator:v1.32.0
+FROM quay.io/operator-framework/ansible-operator:v1.34.1
+
+USER root
+RUN dnf update --security --bugfix -y
+USER 1001
 
 ARG DEFAULT_AI_CONNECT_VERSION
 ARG OPERATOR_VERSION


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-23185

Checking if we can build new artifacts with the latest Operator SDK version and related components.

I tested the resultant `-operator` [image](quay.io/ansible/ansible-ai-connect-operator:0.1.7-pr-92-202405081341) on `minikube` and it successfully installed and deployed an instance of AAIC.