### PR TITLE
AAP-23902: Lightspeed operator: Refactor release workflows: Remove duplication

### DIFF
--- a/.github/workflows/common-build-jobs.yaml
+++ b/.github/workflows/common-build-jobs.yaml
@@ -1,0 +1,69 @@
+name: "Common build and publish related jobs"
+
+on:
+  workflow_call:
+    outputs:
+      latest_ai_connect_version:
+        description: "The latest published version of ansible-ai-connect-service"
+        value: ${{ jobs.initialise.outputs.latest_ai_connect_version }}
+      latest_tag:
+        description: "The _latest_ semver version"
+        value: ${{ jobs.initialise.outputs.latest_tag }}
+      next_tag:
+        description: "The _next_ semver version"
+        value: ${{ jobs.initialise.outputs.next_tag }}
+
+jobs:
+  initialise:
+    runs-on: ubuntu-latest
+
+    outputs:
+      latest_ai_connect_version: ${{ steps.latest_ai_connect_version.outputs.latest_ai_connect_version }}
+      latest_tag: ${{ steps.set_output_parameters.outputs.latest_tag }}
+      next_tag: ${{ steps.set_output_parameters.outputs.next_tag }}
+
+    steps:
+      # ===============================
+      # Checkout code to get tags
+      # -------------------------------
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      # ===============================
+
+      # ===============================
+      # Construct next version
+      # -------------------------------
+      # Read the latest semver tag
+      - name: Get latest tag
+        id: latest_tag
+        uses: WyriHaximus/github-action-get-previous-tag@v1
+        with:
+          fallback: 0.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Increment the latest semver tag for release builds
+      - name: Read semver version
+        id: next_tag
+        uses: WyriHaximus/github-action-next-semvers@v1
+        with:
+          version: ${{ steps.latest_tag.outputs.tag }}
+
+      # Export parameters
+      - name: Set output parameters
+        id: set_output_parameters
+        run: |
+          echo "latest_tag=${{ steps.latest_tag.outputs.tag }}" >> $GITHUB_OUTPUT
+          echo "next_tag=${{ steps.next_tag.outputs.minor }}" >> $GITHUB_OUTPUT
+      # ===============================
+
+      # ===============================
+      # Read the latest ai-connect version
+      # -------------------------------
+      - name: Get latest ai-connect version
+        id: latest_ai_connect_version
+        run: |
+          echo "latest_ai_connect_version=$(jq .ansible_ai_connect_service.imageTag version_info.json)" >> $GITHUB_OUTPUT
+      # ===============================

--- a/.github/workflows/for-pr-build-and-publish-artifacts.yaml
+++ b/.github/workflows/for-pr-build-and-publish-artifacts.yaml
@@ -6,14 +6,20 @@ on:
       - main
 
 jobs:
-  pr_build:
+
+  initialise:
+    uses: ./.github/workflows/common-build-jobs.yaml
+    secrets: inherit
+
+  build:
     runs-on: ubuntu-latest
+    needs: initialise
     env:
       REGISTRY: "quay.io/ansible"
 
     steps:
       # ===============================
-      # Checkout code to get tags
+      # Checkout code
       # -------------------------------
       - uses: actions/checkout@v4
         with:
@@ -25,14 +31,14 @@ jobs:
       # Login to repositories
       # -------------------------------
       - name: Log into registry ghcr.io
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log into target registry
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_USER }}
@@ -42,38 +48,11 @@ jobs:
       # ===============================
       # Construct next version
       # -------------------------------
-      # Read the latest semver tag
-      - name: Get latest tag
-        id: latest_tag
-        uses: WyriHaximus/github-action-get-previous-tag@v1
-        with:
-          fallback: 0.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Increment the latest semver tag for PR builds
-      - name: Read semver version
-        id: next_tag
-        uses: WyriHaximus/github-action-next-semvers@v1
-        with:
-          version: ${{ steps.latest_tag.outputs.tag }}
-
       # Build complete PR version
       - name: Semver tags
         id: version_semver
         run: |
-          echo "IMAGE_SEMVER_VERSION=${{ steps.next_tag.outputs.minor }}-pr-${{ github.event.pull_request.number }}-$(date +'%Y%m%d%H%M')" >> $GITHUB_ENV
-      # ===============================
-
-      # ===============================
-      # Read the latest ai-connect version
-      # -------------------------------
-      # TODO {manstis} This will be read from the file Roger writes to from 'wisdom-service-ops'
-      # JSON is formatted "version": "latest 1.0.202404171921" so skip 'latest '
-      - name: Get latest ai-connect version
-        id: latest_ai_connect_version
-        run: |
-          echo "LATEST_AI_CONNECT_VERSION=$(jq .ansible_ai_connect_service.imageTag version_info.json)" >> $GITHUB_ENV
+          echo "IMAGE_SEMVER_VERSION=${{ needs.initialise.outputs.next_tag }}-pr-${{ github.event.pull_request.number }}-$(date +'%Y%m%d%H%M')" >> $GITHUB_ENV
       # ===============================
 
       # ===============================
@@ -82,7 +61,7 @@ jobs:
       - name: Tag Name
         id: tag_name
         run: |
-          echo "IMAGE_TAGS=-t ${REGISTRY}/ansible-ai-connect-operator:${IMAGE_SEMVER_VERSION}" >> $GITHUB_OUTPUT
+          echo "IMAGE_TAGS=-t ${{ env.REGISTRY }}/ansible-ai-connect-operator:${IMAGE_SEMVER_VERSION}" >> $GITHUB_OUTPUT
           echo "LABEL quay.expires-after=3d" >> ./Dockerfile # tag expires in 3 days
       # ===============================
 
@@ -105,10 +84,10 @@ jobs:
       # -------------------------------
       - name: Build and tag Bundle images
         run: |
-          make bundle bundle-build VERSION=${IMAGE_SEMVER_VERSION} IMG=q${{ env.REGISTRY }}/ansible-ai-connect-operator:${IMAGE_SEMVER_VERSION} BUNDLE_IMG=ansible-ai-connect-bundle:${IMAGE_SEMVER_VERSION}
+          make bundle bundle-build VERSION=${IMAGE_SEMVER_VERSION} IMG=${{ env.REGISTRY }}/ansible-ai-connect-operator:${IMAGE_SEMVER_VERSION} BUNDLE_IMG=ansible-ai-connect-bundle:${IMAGE_SEMVER_VERSION}
 
       - name: Push Bundle images to registry
-        uses: redhat-actions/push-to-registry@v2.7.1
+        uses: redhat-actions/push-to-registry@v2.8
         with:
           image: ansible-ai-connect-bundle
           tags: ${{ env.IMAGE_SEMVER_VERSION }}
@@ -125,7 +104,7 @@ jobs:
           make catalog-build CATALOG_IMG=ansible-ai-connect-catalog:${IMAGE_SEMVER_VERSION} BUNDLE_IMG=${{ env.REGISTRY }}/ansible-ai-connect-bundle:${IMAGE_SEMVER_VERSION}
 
       - name: Push Catalog images to registry
-        uses: redhat-actions/push-to-registry@v2.7.1
+        uses: redhat-actions/push-to-registry@v2.8
         with:
           image: ansible-ai-connect-catalog
           tags: ${{ env.IMAGE_SEMVER_VERSION }}

--- a/.github/workflows/for-release-build-and-publish-artifacts.yaml
+++ b/.github/workflows/for-release-build-and-publish-artifacts.yaml
@@ -5,14 +5,19 @@ on:
     branches: [main]
 
 jobs:
-  release_build:
+  initialise:
+    uses: ./.github/workflows/common-build-jobs.yaml
+    secrets: inherit
+
+  build:
     runs-on: ubuntu-latest
+    needs: initialise
     env:
       REGISTRY: "quay.io/ansible"
 
     steps:
       # ===============================
-      # Checkout code to get tags
+      # Checkout code
       # -------------------------------
       - uses: actions/checkout@v4
         with:
@@ -24,14 +29,14 @@ jobs:
       # Login to repositories
       # -------------------------------
       - name: Log into registry ghcr.io
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log into target registry
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_USER }}
@@ -41,38 +46,11 @@ jobs:
       # ===============================
       # Construct next version
       # -------------------------------
-      # Read the latest semver tag
-      - name: Get latest tag
-        id: latest_tag
-        uses: WyriHaximus/github-action-get-previous-tag@v1
-        with:
-          fallback: 0.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Increment the latest semver tag for release builds
-      - name: Read semver version
-        id: next_tag
-        uses: WyriHaximus/github-action-next-semvers@v1
-        with:
-          version: ${{ steps.latest_tag.outputs.tag }}
-
       # Build complete release version
       - name: Semver tags
         id: version_semver
         run: |
-          echo "IMAGE_SEMVER_VERSION=${{ steps.next_tag.outputs.minor }}" >> $GITHUB_ENV
-      # ===============================
-
-      # ===============================
-      # Read the latest ai-connect version
-      # -------------------------------
-      # TODO {manstis} This will be read from the file Roger writes to from 'wisdom-service-ops'
-      # JSON is formatted "version": "latest 1.0.202404171921" so skip 'latest '
-      - name: Get latest ai-connect version
-        id: latest_ai_connect_version
-        run: |
-          echo "LATEST_AI_CONNECT_VERSION=$(jq .ansible_ai_connect_service.imageTag version_info.json)" >> $GITHUB_ENV
+          echo "IMAGE_SEMVER_VERSION=${{ needs.initialise.outputs.next_tag }}" >> $GITHUB_ENV
       # ===============================
 
       # ===============================
@@ -110,20 +88,20 @@ jobs:
       - name: Update ClusterServiceVersion
         run: |
           # No need to set 'replaces' if there is no previous version
-          if [[ "${{ steps.latest_tag.outputs.tag }}" == "0.0.0" ]]; then
+          if [[ "${{ needs.initialise.outputs.latest_tag }}" == "0.0.0" ]]; then
             >&2 echo "No previous version found."
             exit 0
           fi
           
           # Set 'replaces' to previous version
           VERSION="${IMAGE_SEMVER_VERSION}"
-          PREV_VERSION="${{ steps.latest_tag.outputs.tag }}"
+          PREV_VERSION="${{ needs.initialise.outputs.latest_tag }}"
           if ! grep -qF 'replaces: ansible-ai-connect-operator.v${PREV_VERSION}' bundle/manifests/ansible-ai-connect-operator.clusterserviceversion.yaml; then
             sed -i "/version: ${VERSION}/a \\  replaces: ansible-ai-connect-operator.v${PREV_VERSION}" ./bundle/manifests/ansible-ai-connect-operator.clusterserviceversion.yaml
           fi
 
       - name: Push Bundle images to registry
-        uses: redhat-actions/push-to-registry@v2.7.1
+        uses: redhat-actions/push-to-registry@v2.8
         with:
           image: ansible-ai-connect-bundle
           tags: ${{ env.REGISTRY_TAGS }}
@@ -182,7 +160,7 @@ jobs:
           docker tag ansible-ai-connect-catalog:${IMAGE_SEMVER_VERSION} ansible-ai-connect-catalog:latest
 
       - name: Push Catalog images to registry
-        uses: redhat-actions/push-to-registry@v2.7.1
+        uses: redhat-actions/push-to-registry@v2.8
         with:
           image: ansible-ai-connect-catalog
           tags: ${{ env.REGISTRY_TAGS }}


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-23902

In reality, there was little that could be re-used; just the code that gets the tags really.

It is only possible to re-use a whole _job_ and not individual _steps_.

Each _job_ runs on its own GitHub `runner` and hence checkouts/local docker builds are not shared between _jobs_. 