### PR TITLE
AAP-24323: postgres_storage_class is not taken the default from the cluster

### DIFF
--- a/config/crd/bases/aiconnect.ansible.com_ansibleaiconnects.yaml
+++ b/config/crd/bases/aiconnect.ansible.com_ansibleaiconnects.yaml
@@ -129,6 +129,33 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  node_selector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector for the database pod.
+                    type: object
+                  postgres_data_volume_init:
+                    description: Sets permissions on the /var/lib/pgdata/data for postgres container using an init container (not Openshift)
+                    type: boolean
+                    default: false
+                  postgres_init_container_commands:
+                    description: Customize the postgres init container commands (Non Openshift)
+                    type: string
+                  postgres_extra_args:
+                    description: Arguments to pass to postgres process
+                    items:
+                      type: string
+                    type: array
+                  priority_class:
+                    description: Assign a pre-existing priority class to the postgres pod
+                    type: string
+                  postgres_storage_class:
+                    description: Storage class to use for the PostgreSQL PVC
+                    type: string
+                  postgres_ssl_mode:
+                    description: 'Configure PostgreSQL connection sslmode option.
+                      Default: "prefer"'
+                    type: string
                   storage_requirements:
                     description: Storage requirements for the PostgreSQL container
                     properties:
@@ -142,11 +169,6 @@ spec:
                           storage:
                             type: string
                         type: object
-                    type: object
-                  node_selector:
-                    additionalProperties:
-                      type: string
-                    description: NodeSelector for the database pod.
                     type: object
                   tolerations:
                     description: Node tolerations for the database pod.
@@ -189,21 +211,6 @@ spec:
                           type: string
                       type: object
                     type: array
-                  priority_class:
-                    description: Assign a pre-existing priority class to the postgres pod
-                    type: string
-                  postgres_data_path:
-                    description: 'Registry path to the PostgreSQL container to use.
-                      Default: "/var/lib/pgsql/data/userdata"'
-                    type: string
-                  postgres_extra_args:
-                    description: Arguments to pass to postgres process
-                    items:
-                      type: string
-                    type: array
-                  postgres_storage_class:
-                    description: Storage class to use for the PostgreSQL PVC
-                    type: string
                 type: object
               api:
                 description: Defines desired state of the resources

--- a/config/manifests/bases/ansible-ai-connect-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ansible-ai-connect-operator.clusterserviceversion.yaml
@@ -115,11 +115,6 @@ spec:
         path: database.priority_class
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - displayName: Database data path
-        path: database.postgres_data_path
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Database Extra Arguments
         path: database.postgres_extra_args
         x-descriptors:

--- a/config/samples/aiconnect_v1alpha1_ansibleaiconnect.yaml
+++ b/config/samples/aiconnect_v1alpha1_ansibleaiconnect.yaml
@@ -14,5 +14,3 @@ spec:
   ingress_type: Route
   auth_config_secret_name: 'auth-configuration-secret'
   model_config_secret_name: 'model-configuration-secret'
-  database:
-    postgres_storage_class: standard

--- a/docs/user-guide/database-configuration.md
+++ b/docs/user-guide/database-configuration.md
@@ -1,0 +1,116 @@
+### Database Configuration
+
+#### PostgreSQL Version
+
+The default PostgreSQL version for the version of `AnsibleAIConnect` bundled with the latest version of the ansible-ai-connect-operator is PostgreSQL 15. You can find this default for a given version by at the default value for [supported_pg_version](./roles/postgres/vars/main.yml).
+
+We only have coverage for the default version of PostgreSQL. Newer versions of PostgreSQL will likely work, but should only be configured as an external database. If your database is managed by the operator (default if you don't specify a `postgres_configuration_secret`), then you should not override the default version as this may cause issues when operator tries to upgrade your postgresql pod.
+
+#### External PostgreSQL Service
+
+To configure `AnsibleAIConnect` to use an external database, the Custom Resource needs to know about the connection details. To do this, create a k8s secret with those connection details and specify the name of the secret as `postgres_configuration_secret` at the CR spec level.
+
+
+The secret should be formatted as follows:
+
+```yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <resourcename>-postgres-configuration
+  namespace: <target namespace>
+stringData:
+  host: <external ip or url resolvable by the cluster>
+  port: <external port, this usually defaults to 5432>
+  database: <desired database name>
+  username: <username to connect as>
+  password: <password to connect with>
+  sslmode: prefer
+  type: unmanaged
+type: Opaque
+```
+
+> It is possible to set a specific username, password, port, or database, but still have the database managed by the operator. In this case, when creating the postgres-configuration secret, the `type: managed` field should be added.
+
+**Note**: The variable `sslmode` is valid for `external` databases only. The allowed values are: `prefer`, `disable`, `allow`, `require`, `verify-ca`, `verify-full`.
+
+Once the secret is created, you can specify it on your spec:
+
+```yaml
+---
+spec:
+  ...
+  postgres_configuration_secret: <name-of-your-secret>
+```
+
+#### Managed PostgreSQL Service
+
+If you don't have access to an external PostgreSQL service, the `AnsibleAIConnect` operator can deploy one for you alongside the `AnsibleAIConnect` instance itself.
+
+The following variables are customizable for the managed PostgreSQL service
+
+| Name                                          | Description                                   | Default                                |
+| --------------------------------------------- | --------------------------------------------- | -------------------------------------- |
+| postgres_image                                | Path of the image to pull                     | quay.io/sclorg/postgresql-15-c9s       |
+| postgres_image_version                        | Image version to pull                         | c9s                                    |
+| database.resource_requirements                | PostgreSQL container resource requirements    | requests: {cpu: 50m, memory: 100Mi}    |
+| database.storage_requirements                 | PostgreSQL container storage requirements     | requests: {storage: 8Gi}               |
+| database.postgres_storage_class               | PostgreSQL PV storage class                   | Empty string                           |
+| database.priority_class                       | Priority class used for PostgreSQL pod        | Empty string                           |
+| database.postgres_data_volume_init                |  Initialize PostgreSQL data directory with the correct permissions | false |
+
+Example of customization could be:
+
+```yaml
+---
+spec:
+  ...
+  database:
+    resource_requirements:
+      requests:
+        cpu: 500m
+        memory: 2Gi
+      limits:
+        cpu: '1'
+        memory: 4Gi
+    storage_requirements:
+      requests:
+        storage: 8Gi
+    postgres_storage_class: fast-ssd
+    postgres_data_volume_init: true
+    postgres_extra_args:
+      - '-c'
+      - 'max_connections=1000'
+```
+
+**Note**: If `database.postgres_storage_class` is not defined, PostgreSQL will store it's data on a volume using the default storage class for your cluster.
+
+#### Note about overriding the postgres image
+
+We recommend you use the default image sclorg image. If you override the postgres image to use a custom postgres image like `postgres:15` for example, the default data directory path may be different. These images cannot be used interchangeably.
+
+You can no longer configure a custom `postgres_data_path` because it is hardcoded in the quay.io/sclorg/postgresql-15-c9s image.
+
+#### Note about Postgres data volume initialization
+
+When using a hostPath backed PVC and some other storage classes like longhorn storage, the postgres data directory needs to be accessible by the user in the postgres pod (UID 26).
+
+To initialize this directory with the correct permissions, add `database.postgres_data_volume_init: true` to EDA instance.
+
+```yaml
+spec:
+  database:
+    postgres_data_volume_init: true
+```
+
+Should you need to modify the init container commands, there is an example below.
+
+```yaml
+spec:
+  database:
+    postgres_data_volume_init: true
+    postgres_init_container_commands: |
+      chown 26:0 /var/lib/pgsql/data
+      chmod 700 /var/lib/pgsql/data
+```

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -16,3 +16,7 @@ service_account_annotations: ''
 # This should be true if using the operator loop.
 # Set to false to run a role locally for testing.
 set_self_labels: true
+
+# Used to determine some cluster specific logic
+is_k8s: false
+is_openshift: false

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,4 +1,23 @@
 ---
+- name: Get information about the cluster
+  set_fact:
+    api_groups: "{{ lookup('k8s', cluster_info='api_groups') }}"
+  when:
+    - not is_openshift | bool
+    - not is_k8s | bool
+
+- name: Determine the cluster type
+  set_fact:
+    is_openshift: "{{ True if 'route.openshift.io' in api_groups else False }}"
+    is_k8s: "{{ False if 'route.openshift.io' in api_groups else True }}"
+  when:
+    - not is_openshift | bool
+    - not is_k8s | bool
+
+# Indicate what kind of cluster we are in (OpenShift or Kubernetes).
+- debug:
+    msg: "CLUSTER TYPE: is_openshift={{ is_openshift }}; is_k8s={{ is_k8s }}"
+
 # Tasks file for AnsibleAIConnect
 
 - name: Create AnsibleAIConnect ServiceAccount

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -49,10 +49,11 @@ _database:
   node_selector: ''
   tolerations: ''
   priority_class: ''
-  postgres_data_path: '/var/lib/pgsql/data/userdata'
   postgres_extra_args: ''
-  postgres_storage_class: ''
-
+  postgres_data_volume_init: false
+  postgres_init_container_commands: |
+    chown 26:0 /var/lib/pgsql/data
+    chmod 700 /var/lib/pgsql/data
 
 image_pull_policy: IfNotPresent
 image_pull_secrets: []

--- a/roles/postgres/templates/postgres.statefulset.yaml.j2
+++ b/roles/postgres/templates/postgres.statefulset.yaml.j2
@@ -51,6 +51,24 @@ spec:
       tolerations:
         {{ combined_database.tolerations | indent(width=8) }}
 {% endif %}
+{% if combined_database.postgres_data_volume_init and not is_openshift %}
+      initContainers:
+        - name: init
+          image: '{{ _postgres_image }}'
+          imagePullPolicy: '{{ image_pull_policy }}'
+          securityContext:
+            runAsUser: 0
+          command:
+            - /bin/sh
+            - -c
+            - |
+              {{ combined_database.postgres_init_container_commands | indent(width=14) }}
+          resources: {{ combined_database.resource_requirements }}
+          volumeMounts:
+            - name: postgres-{{ supported_pg_version }}
+              mountPath: '{{ _postgres_data_path | dirname }}'
+              subPath: '{{ _postgres_data_path | dirname | basename }}'
+{% endif %}
       containers:
         - image: '{{ _postgres_image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
@@ -106,8 +124,8 @@ spec:
               name: postgres-{{ supported_pg_version }}
           volumeMounts:
             - name: postgres-{{ supported_pg_version }}
-              mountPath: '{{ combined_database.postgres_data_path | dirname }}'
-              subPath: '{{ combined_database.postgres_data_path | dirname | basename }}'
+              mountPath: '{{ _postgres_data_path | dirname }}'
+              subPath: '{{ _postgres_data_path | dirname | basename }}'
 {% if combined_database.resource_requirements is defined %}
           resources: {{ combined_database.resource_requirements }}
 {% endif %}

--- a/roles/postgres/vars/main.yml
+++ b/roles/postgres/vars/main.yml
@@ -2,3 +2,4 @@
 # vars file for PostgreSQL database
 
 supported_pg_version: 15
+_postgres_data_path: '/var/lib/pgsql/data/userdata'


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-24323

This PR aligns `AnsibleAIConnect` Postgres configuration with `eda-server-operator`.

I tried deploying an instance of AAIC without specifying `postgres_storage_class` on OpenShift and it seemed to work fine.

@romartin @jameswnl Could you please verify my test before merging.