### PR TITLE
Fix small typo in CSV API deployment block

### DIFF
--- a/config/crd/bases/aiconnect.ansible.com_ansibleaiconnects.yaml
+++ b/config/crd/bases/aiconnect.ansible.com_ansibleaiconnects.yaml
@@ -634,7 +634,7 @@ spec:
                 type: string
                 default: admin
               admin_email:
-                description: email address to use for the admin account
+                description: E-mail address to use for the admin account
                 type: string
                 default: test@example.com
               admin_password_secret:

--- a/config/manifests/bases/ansible-ai-connect-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ansible-ai-connect-operator.clusterserviceversion.yaml
@@ -52,12 +52,12 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: Defines desired state of AI deployment resources
+      - description: Defines desired state of API deployment resources
         displayName: API deployment configuration
         path: api
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: The number of API replicas.
+      - description: The number of API replicas
         displayName: Replicas
         path: api.replicas
         x-descriptors:
@@ -77,12 +77,12 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:updateStrategy
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: Node tolerations for the pods.
+      - description: Node tolerations for the pods
         displayName: Tolerations
         path: api.tolerations
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: Topology rule(s) for the pods.
+      - description: Topology rule(s) for the pods
         displayName: Topology Spread Constraints
         path: api.topology_spread_constraints
         x-descriptors:
@@ -244,7 +244,8 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Secret where the trusted Certificate Authority Bundle is stored
+      - displayName: Bundle CA Certificate Secret
+        description: Secret where the trusted Certificate Authority Bundle is stored
         path: bundle_cacert_secret
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
@@ -266,6 +267,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
+      - displayName: Admin E-mail Address
+        path: admin_email
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+        - urn:alm:descriptor:com.tectonic.ui:text
       - displayName: API Extra Settings
         path: extra_settings
         x-descriptors:


### PR DESCRIPTION
I think this is supposed to be `API deployment`, not `AI deployment`

![image](https://github.com/ansible/ansible-ai-connect-operator/assets/11698892/f160609a-3679-477f-88db-1d150dfa2fd8)


@manstis Feel free to close if that is not the case.


This also has an addition for a displayName for bundle_cacert_secret in the CSV.  Without it, it displays like this:

![image](https://github.com/ansible/ansible-ai-connect-operator/assets/11698892/dea96387-4e7c-4c7e-a129-368d1d3b4aae)

It was unclear whether admin_email was required or not.  I hid it though since there is no user management in the ansible-ai-connect app so users won't care much about this setting.  We could probably just remove this parameter all together and use the value set in defaults/main.yml if it is required by `django-admin createsuperuser`. I defer to you on that  @manstis @jameswnl 