### PR TITLE
Enable oc explain by removing preserve-unknown-fields behavior

### DIFF
--- a/config/crd/bases/aiconnect.ansible.com_ansibleaiconnects.yaml
+++ b/config/crd/bases/aiconnect.ansible.com_ansibleaiconnects.yaml
@@ -32,7 +32,6 @@ spec:
           spec:
             description: Spec defines the desired state of AnsibleAIConnect
             type: object
-            x-kubernetes-preserve-unknown-fields: true
             required:
               - auth_config_secret_name
               - model_config_secret_name
@@ -699,7 +698,6 @@ spec:
                   type: object
                 type: array
             type: object
-            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: true


### PR DESCRIPTION
- See https://github.com/kubernetes/kubernetes/issues/82407 for explanation

<details open>
  <summary>--- Before this change ---</summary>

```
$ oc explain ansiblelightspeeds
KIND:     AnsibleLightspeed
VERSION:  lightspeed.ansible.com/v1alpha1

DESCRIPTION:
     AnsibleAIConnect is the Schema for the ansibleaiconnects API

FIELDS:
   apiVersion	<string>
     APIVersion defines the versioned schema of this representation of an
     object. Servers should convert recognized schemas to the latest internal
     value, and may reject unrecognized values. More info:
     https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources

   kind	<string>
     Kind is a string value representing the REST resource this object
     represents. Servers may infer this from the endpoint the client submits
     requests to. Cannot be updated. In CamelCase. More info:
     https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds

   metadata	<Object>
     Standard object's metadata. More info:
     https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

   spec	<>
     Spec defines the desired state of AnsibleAIConnect

   status	<>
     Status defines the observed state of AnsibleAIConnect
```
</details>


<details open>
  <summary>--- After this change ---</summary>

```
$ oc explain ansiblelightspeeds.spec
KIND:     AnsibleLightspeed
VERSION:  lightspeed.ansible.com/v1alpha1

RESOURCE: spec <Object>

DESCRIPTION:
     Spec defines the desired state of AnsibleAIConnect

FIELDS:
   additional_labels	<[]string>
     Additional labels defined on the resource, which should be propagated to
     child resources

   admin_email	<string>
     email address to use for the admin account

   admin_password_secret	<string>
     Secret where the admin password can be found. If not specified, one will be
     generated.

   admin_user	<string>
     Username to use for the admin account

   api	<Object>
     Defines desired state of the resources

   auth_config_secret_name	<string> -required-
     Secret where the authentication configuration can be found

   bundle_cacert_secret	<string>
     Secret where the trusted Certificate Authority Bundle is stored

   database	<Object>
     The PostgreSQL database StatefulSet

   db_fields_encryption_secret	<string>
     Secret where the DB fields encryption key can be found. If not specified,
     one will be generated.

   extra_settings	<[]Object>
     Environment variables to configure the application-level settings

   hostname	<string>
     The hostname of the instance

   image	<string>
     Registry path to API container image to use

   image_pull_policy	<string>
     The image pull policy

   image_pull_secrets	<[]string>
     Image pull secrets for the API and database containers

   image_version	<string>
     API container image tag or version to use

   ingress_annotations	<string>
     Annotations to add to the Ingress Controller

   ingress_api_version	<string>
     The Ingress API version to use

   ingress_class_name	<string>
     The name of ingress class to use instead of the cluster default.

   ingress_path	<string>
     The ingress path used to reach the deployed service

   ingress_path_type	<string>
     The ingress path type for the deployed service

   ingress_tls_secret	<string>
     Secret where the Ingress TLS secret can be found

   ingress_type	<string>
     The ingress type to use to reach the deployed instance

   loadbalancer_port	<integer>
     Port to use for the loadbalancer

   loadbalancer_protocol	<string>
     Protocol to use for the loadbalancer

   model_config_secret_name	<string> -required-
     Secret where the model configuration can be found

   no_log	<boolean>
     Configure no_log for no log tasks

   nodeport_port	<integer>
     Port to use for the nodeport

   postgres_image	<string>
     Registry path to the PostgreSQL container to use

   postgres_image_version	<string>
     PostgreSQL container image version to use

   route_api_version	<string>
     The route API version to use

   route_host	<string>
     The DNS to use to points to the instance

   route_tls_secret	<string>
     Secret where the TLS related credentials are stored

   route_tls_termination_mechanism	<string>
     The secure TLS termination mechanism to use

   service_account_annotations	<string>
     ServiceAccount annotations

   service_annotations	<string>
     Service annotations

   service_type	<string>
     The service type to be used on the deployed instance

   set_self_labels	<boolean>
     Maintain some of the recommended `app.kubernetes.io/*` labels on the
     resource (self)
```
</details>