### PR TITLE
AAP-24914: Operator: Re-enable required checks

### DIFF
--- a/.github/workflows/merge-gatekeeper.yaml
+++ b/.github/workflows/merge-gatekeeper.yaml
@@ -1,0 +1,19 @@
+---
+name: Merge Gatekeeper
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  merge-gatekeeper:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      statuses: read
+    steps:
+      - name: Run Merge Gatekeeper
+        uses: upsidr/merge-gatekeeper@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-24914

This PR adds an Action that acts as the "gateway" for PR merges. See https://github.com/upsidr/merge-gatekeeper

This allows us to run `Molecule Tests (Kind)` for code changes but not documentation etc and still prevent PRs from being merged until all applicable checks have passed. We will need to reconfigure the repository settings so that `merge-gatekeeper` is the *required* action.

 


