### PR TITLE
AAP-24976: [DAST] Lightspeed Downstream: Cookie with SameSite Attribute None

### DIFF
--- a/roles/model/templates/model.ingress.yaml.j2
+++ b/roles/model/templates/model.ingress.yaml.j2
@@ -12,6 +12,8 @@ metadata:
 {% if ingress_annotations %}
   annotations:
     {{ ingress_annotations | indent(width=4) }}
+    nginx.ingress.kubernetes.io/session-cookie-samesite: Lax
+    nginx.ingress.kubernetes.io/session-cookie-name: r_p_session
 {% endif %}
 spec:
 {% if ingress_class_name %}
@@ -47,6 +49,9 @@ kind: Route
 metadata:
   name: '{{ ansible_operator_meta.name }}'
   namespace: '{{ ansible_operator_meta.namespace }}'
+  annotations:
+    router.openshift.io/cookie-same-site: Lax
+    router.openshift.io/cookie_name: r_p_session
   labels:
     {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(width=4) | trim }}
 spec:


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-24976

This is the equivalent to https://github.com/ansible/ansible-wisdom-ops/pull/856 for "onprem".

"downstream" will receive this change to "upstream".