### PR TITLE
[DRAFT] AAP-24977: [DAST] Lightspeed Downstream: Server Leaks Version Information via 'Server' HTTP Response Header Field

### DIFF
--- a/roles/model/templates/model.ingress.yaml.j2
+++ b/roles/model/templates/model.ingress.yaml.j2
@@ -79,4 +79,12 @@ spec:
     name: {{ ansible_operator_meta.name }}-api
     weight: 100
   wildcardPolicy: None
+  httpHeaders:
+      actions:
+        response:
+        - name: Server
+          action:
+            type: Set
+            set:
+              value: nginx
 {% endif %}


### PR DESCRIPTION
**=== DRAFT ===**

See https://issues.redhat.com/browse/AAP-24977

An alternative, if this does not work, is to prevent it from being added by `nginx` in `ansible-ai-connect-service` configuration:
```
http {
    ...
    server {
        server_tokens off;
        ...
    }
}
```