### PR TITLE
AAP-25066: Operator: Support Postgres version updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A Kubernetes operator for Kubernetes built with [Operator SDK](https://github.co
   - [Deploy an `AnsibleAIConnect` instance](#deploy-an-ansibleaiconnect-instance)
     - [Deploying on OpenShift `ROSA`](#deploying-on-openshift-rosa)
     - [Deploying on `minikube`](#deploying-on-minikube)
+  - [Upgrades](#upgrades)
   - [Integrating with Ansible Automation Platform and IBM watsonx Code Assistant](#integrating-with-ansible-automation-platform-and-ibm-watsonx-code-assistant)
   - [Advanced Configuration](#advanced-configuration)
     - [Use external database](#use-external-database)
@@ -92,6 +93,10 @@ Full instructions for using a `minikube` cluster are [here](./docs/running-on-mi
 ## Integrating with Ansible Automation Platform and IBM watsonx Code Assistant
 
 Go [here](docs/aap-wca-integrations.md)
+
+## Upgrades
+
+For information on how to upgrade, please see the [upgrading](./docs/upgrade/upgrading.md) document.
 
 ## Advanced Configuration
 

--- a/config/crd/bases/aiconnect.ansible.com_ansibleaiconnects.yaml
+++ b/config/crd/bases/aiconnect.ansible.com_ansibleaiconnects.yaml
@@ -155,6 +155,10 @@ spec:
                     description: 'Configure PostgreSQL connection sslmode option.
                       Default: "prefer"'
                     type: string
+                  postgres_keep_pvc_after_upgrade:
+                    description: Specify whether or not to keep the old PVC after PostgreSQL upgrades
+                    type: boolean
+                    default: true
                   storage_requirements:
                     description: Storage requirements for the PostgreSQL container
                     properties:
@@ -673,6 +677,9 @@ spec:
                 type: string
               dbFieldsEncryptionSecret:
                 description: Database Fields Encryption secret name of the deployed instance
+                type: string
+              upgradedPostgresVersion:
+                description: Status to indicate that the database has been upgraded to the version in the status
                 type: string
               image:
                 description: URL of the image used for the deployed instance

--- a/config/manifests/bases/ansible-ai-connect-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ansible-ai-connect-operator.clusterserviceversion.yaml
@@ -115,6 +115,11 @@ spec:
         path: database.priority_class
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: Should PostgreSQL data for managed databases be kept after upgrades?
+        path: database.postgres_keep_pvc_after_upgrade
+        x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:advanced
+          - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - displayName: Database Extra Arguments
         path: database.postgres_extra_args
         x-descriptors:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -98,6 +98,13 @@ rules:
       - update
       - watch
   - apiGroups:
+      - apps
+    resources:
+      - statefulsets/scale
+      - deployments/scale
+    verbs:
+      - patch
+  - apiGroups:
       - ""
     resources:
       - pods/exec

--- a/docs/upgrade/upgrading.md
+++ b/docs/upgrade/upgrading.md
@@ -1,0 +1,51 @@
+### Upgrading
+
+Before upgrading, please review the changelog for any breaking or notable changes in the releases between your current version and the one you are upgrading to. These changes can be found on the [Release page](https://github.com/ansible/ansible-ai-connect-operator/releases).
+
+
+An operator version pins to a specific version of `ansible-ai-connect-service` which is the latest version at the time of the operator release.
+
+To find the version of `ansible-ai-connect-service` that will be installed by the operator, check the version specified in the `DEFAULT_AI_CONNECT_VERSION` variable for that particular release. You can do so by running the following command
+
+```shell
+OPERATOR_VERSION=1.0.1
+docker run --entrypoint="" quay.io/ansible/ansible-ai-connect-operator:$OPERATOR_VERSION bash -c "env | egrep DEFAULT_AI_CONNECT_VERSION"
+```
+
+Follow the installation instructions (`make deploy`, `kustomization`, etc) using the new release version to apply the new operator `yaml` and upgrade the operator. This will in turn also upgrade your `AnsibleAIConnect` deployment.
+
+For example, if you installed with `kustomize`, you could modify the version in your `kustomization.yaml` file from `1.0.0` to `1.0.1` and then apply it.
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - config/default
+
+# Set the image tags to match the git version from above
+images:
+  - name: quay.io/ansible/ansible-ai-connect-operator
+    newTag: 1.0.1
+
+# Specify a custom namespace in which to install AnsibleAIConnect
+namespace: ansible-ai-connect
+```
+
+Then run this to apply it:
+
+```
+kustomize build . | kubectl apply -f -
+```
+
+#### PostgreSQL Upgrade Considerations
+
+If there is a PostgreSQL major version upgrade, after the data directory on the `PersistentVolumeClaim` is migrated to the new version, the old `PersistentVolumeClaim` is kept by default.
+
+This provides the ability to roll back if needed, but can take up extra storage space in your cluster unnecessarily. By default, the Postgres `PersistentVolumeClaim` from the previous version will remain unless you manually remove it, or have the `database.postgres_keep_pvc_after_upgrade` parameter set to `false`. You can configure it to be deleted automatically
+after a successful upgrade by setting the following variable on the `AnsibleAIConnect` specification.
+
+```yaml
+  spec:
+    database:
+        postgres_keep_pvc_after_upgrade: false
+```

--- a/docs/user-guide/database-configuration.md
+++ b/docs/user-guide/database-configuration.md
@@ -2,7 +2,7 @@
 
 #### PostgreSQL Version
 
-The default PostgreSQL version for the version of `AnsibleAIConnect` bundled with the latest version of the ansible-ai-connect-operator is PostgreSQL 15. You can find this default for a given version by at the default value for [supported_pg_version](./roles/postgres/vars/main.yml).
+The default PostgreSQL version for the version of `AnsibleAIConnect` bundled with the latest version of the `ansible-ai-connect-operator` is PostgreSQL 15. You can find this default for a given version by at the default value for [supported_pg_version](./roles/postgres/vars/main.yml).
 
 We only have coverage for the default version of PostgreSQL. Newer versions of PostgreSQL will likely work, but should only be configured as an external database. If your database is managed by the operator (default if you don't specify a `postgres_configuration_secret`), then you should not override the default version as this may cause issues when operator tries to upgrade your postgresql pod.
 
@@ -31,6 +31,8 @@ stringData:
 type: Opaque
 ```
 
+> Please ensure that the value for the variable `password` should _not_ contain single or double quotes (`'`, `"`) or backslashes (`\`) to avoid any issues during deployment.
+
 > It is possible to set a specific username, password, port, or database, but still have the database managed by the operator. In this case, when creating the postgres-configuration secret, the `type: managed` field should be added.
 
 **Note**: The variable `sslmode` is valid for `external` databases only. The allowed values are: `prefer`, `disable`, `allow`, `require`, `verify-ca`, `verify-full`.
@@ -58,7 +60,6 @@ The following variables are customizable for the managed PostgreSQL service
 | database.storage_requirements                 | PostgreSQL container storage requirements     | requests: {storage: 8Gi}               |
 | database.postgres_storage_class               | PostgreSQL PV storage class                   | Empty string                           |
 | database.priority_class                       | Priority class used for PostgreSQL pod        | Empty string                           |
-| database.postgres_data_volume_init                |  Initialize PostgreSQL data directory with the correct permissions | false |
 
 Example of customization could be:
 
@@ -78,7 +79,6 @@ spec:
       requests:
         storage: 8Gi
     postgres_storage_class: fast-ssd
-    postgres_data_volume_init: true
     postgres_extra_args:
       - '-c'
       - 'max_connections=1000'
@@ -90,27 +90,4 @@ spec:
 
 We recommend you use the default image sclorg image. If you override the postgres image to use a custom postgres image like `postgres:15` for example, the default data directory path may be different. These images cannot be used interchangeably.
 
-You can no longer configure a custom `postgres_data_path` because it is hardcoded in the quay.io/sclorg/postgresql-15-c9s image.
-
-#### Note about Postgres data volume initialization
-
-When using a hostPath backed PVC and some other storage classes like longhorn storage, the postgres data directory needs to be accessible by the user in the postgres pod (UID 26).
-
-To initialize this directory with the correct permissions, add `database.postgres_data_volume_init: true` to EDA instance.
-
-```yaml
-spec:
-  database:
-    postgres_data_volume_init: true
-```
-
-Should you need to modify the init container commands, there is an example below.
-
-```yaml
-spec:
-  database:
-    postgres_data_volume_init: true
-    postgres_init_container_commands: |
-      chown 26:0 /var/lib/pgsql/data
-      chmod 700 /var/lib/pgsql/data
-```
+You can no longer configure a custom `postgres_data_path` because it is hardcoded in the `quay.io/sclorg/postgresql-15-c9s` image.

--- a/roles/model/tasks/update_status.yml
+++ b/roles/model/tasks/update_status.yml
@@ -55,3 +55,13 @@
         status:
           URL: "https://{{ route_url['resources'][0]['status']['ingress'][0]['host'] }}"
   when: ingress_type | lower == 'route'
+
+- name: Update upgradedPostgresVersion status
+  operator_sdk.util.k8s_status:
+    api_version: '{{ api_version }}'
+    kind: "{{ kind }}"
+    name: "{{ ansible_operator_meta.name }}"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    status:
+      upgradedPostgresVersion: "{{ upgraded_postgres_version | string }}"
+  when: upgraded_postgres_version is defined

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -50,6 +50,7 @@ _database:
   tolerations: ''
   priority_class: ''
   postgres_extra_args: ''
+  postgres_keep_pvc_after_upgrade: true  # Specify whether or not to keep the old PVC after PostgreSQL upgrades
   postgres_data_volume_init: false
   postgres_init_container_commands: |
     chown 26:0 /var/lib/pgsql/data

--- a/roles/postgres/tasks/check_postgres_version.yml
+++ b/roles/postgres/tasks/check_postgres_version.yml
@@ -1,0 +1,76 @@
+---
+
+# It is possible that N-2 postgres Pods may still be present in the namespace from previous upgrades.
+# So we have to take that into account and preferentially set the most recent one.
+- name: Get the old postgres pod (N-1)
+  k8s_info:
+    kind: Pod
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    field_selectors:
+      - status.phase=Running
+  register: _running_pods
+
+- block:
+    - name: Filter Pods by name
+      set_fact:
+        filtered_old_postgres_pods: "{{ _running_pods.resources |
+        selectattr('metadata.name', 'match', ansible_operator_meta.name + '-postgres.*-0') |
+        rejectattr('metadata.name', 'search', '-' + supported_pg_version | string + '-0') |
+        list }}"
+
+    # Sort pods by name in reverse order (most recent PG version first) and set
+    - name: Set info for previous Postgres Pod
+      set_fact:
+        sorted_old_postgres_pods: "{{ filtered_old_postgres_pods |
+        sort(attribute='metadata.name') |
+        reverse | list }}"
+      when: filtered_old_postgres_pods | length
+
+    - name: Set info for previous Postgres Pod
+      set_fact:
+        old_postgres_pod: "{{ sorted_old_postgres_pods | first }}"
+      when: filtered_old_postgres_pods | length
+  when: _running_pods.resources | length
+
+- name: Look up details for this Deployment
+  k8s_info:
+    api_version: "{{ api_version }}"
+    kind: "{{ kind }}"
+    name: "{{ ansible_operator_meta.name }}"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+  register: this_ansibleaiconnect
+
+# If this deployment has been upgraded before or if upgrade has already been started, set this var
+- name: Set previous Postgres version var
+  set_fact:
+    _previous_upgraded_pg_version: "{{ this_ansibleaiconnect['resources'][0]['status']['upgradedPostgresVersion'] | default(false) }}"
+  when:
+    - "'upgradedPostgresVersion' in this_ansibleaiconnect['resources'][0]['status']"
+
+- name: Check if Postgres Pod is running an older version
+  block:
+    - name: Set path to PG_VERSION file for given container image
+      set_fact:
+        path_to_pg_version: '{{ _postgres_data_path }}/PG_VERSION'
+
+    - name: Get old Postgres version
+      k8s_exec:
+        namespace: "{{ ansible_operator_meta.namespace }}"
+        pod: "{{ old_postgres_pod['metadata']['name'] }}"
+        command: |
+          bash -c """
+          cat {{ path_to_pg_version }}
+          """
+      register: _old_pg_version
+
+    - debug:
+        msg: "--- Upgrading from {{ old_postgres_pod['metadata']['name'] | default('NONE')}} Pod ---"
+
+    - name: Upgrade data dir from old Postgres to {{ supported_pg_version }} if applicable
+      include_tasks: upgrade_postgres.yml
+      when:
+        - (_old_pg_version.stdout | default(0) | int ) < supported_pg_version
+  when:
+    - managed_database
+    - (_previous_upgraded_pg_version | default(false)) | ternary(_previous_upgraded_pg_version | int < supported_pg_version, true)
+    - old_postgres_pod | length  # If empty, then old Postgres Pod has been removed, and we can assume the upgrade is complete

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -13,6 +13,11 @@
 - name: Set variables to be used in Postgres templates
   import_tasks: set_variables.yml
 
+# Managed Database block
+- name: Check PostgreSQL version to determine if an upgrade is needed
+  import_tasks: check_postgres_version.yml
+  when: managed_database
+
 - name: Create managed Postgres StatefulSet if no external db is defined
   import_tasks: create_managed_postgres.yml
   when: managed_database

--- a/roles/postgres/tasks/scale_down_deployment.yml
+++ b/roles/postgres/tasks/scale_down_deployment.yml
@@ -1,0 +1,19 @@
+---
+
+- name: Check for presence of Deployment
+  k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: "{{ ansible_operator_meta.name }}-api"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+  register: this_deployment
+
+- name: Scale down Deployment for migration
+  kubernetes.core.k8s_scale:
+    api_version: apps/v1
+    kind: Deployment
+    name: "{{ ansible_operator_meta.name }}-api"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    replicas: 0
+    wait: yes
+  when: this_deployment['resources'] | length

--- a/roles/postgres/tasks/upgrade_postgres.yml
+++ b/roles/postgres/tasks/upgrade_postgres.yml
@@ -1,0 +1,182 @@
+---
+
+# Upgrade Postgres (Managed Databases only)
+#  * If Postgres version is not supported_pg_version, and not an external postgres instance (when managed_database is yes),
+#  * Data will be streamed via a pg_dump from the Postgres 12/13 Pod to the Postgres supported_pg_version Pod via a pg_restore.
+
+- name: Scale down Deployment for migration
+  include_tasks: scale_down_deployment.yml
+
+- name: Delete existing Postgres configuration Secret
+  k8s:
+    api_version: v1
+    kind: Secret
+    name: "{{ ansible_operator_meta.name }}-postgres-configuration"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    state: absent
+    wait: yes
+
+- name: Create database configuration with new -postgres-{{ supported_pg_version }} hostname
+  k8s:
+    apply: true
+    definition: "{{ lookup('template', 'postgres_upgrade_secret.yaml.j2') }}"
+  no_log: "{{ no_log }}"
+
+- name: Set new database var to be used when configuring app credentials
+  set_fact:
+    ansibleaiconnect_postgres_host: "{{ ansible_operator_meta.name }}-postgres-{{ supported_pg_version }}"
+  no_log: "{{ no_log }}"
+
+- name: Create Service and StatefulSet
+  k8s:
+    apply: yes
+    definition: "{{ lookup('template', item + '.yaml.j2') }}"
+    wait: yes
+  loop:
+    - 'postgres.service'
+    - 'postgres.statefulset'
+  register: create_statefulset_result
+
+- name: Check database resources
+  k8s:
+    apply: yes
+    definition: "{{ lookup('template', item + '.yaml.j2') }}"
+    wait: no
+  register: postgres_resources_result
+  loop:
+    - 'postgres.service'
+    - 'postgres.statefulset'
+  no_log: "{{ no_log }}"
+
+- name: Set Postgres label if not defined by user
+  set_fact:
+    postgres_label_selector: "app.kubernetes.io/instance=postgres-{{ supported_pg_version }}-{{ ansible_operator_meta.name }}"
+  when: postgres_label_selector is not defined
+
+- name: Get new Postgres Pod information
+  k8s_info:
+    kind: Pod
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    label_selectors:
+      - "{{ postgres_label_selector }}"
+    field_selectors:
+      - status.phase=Running
+  register: postgres_pod
+  until:
+    - "postgres_pod['resources'] | length"
+    - "postgres_pod['resources'][0]['status']['phase'] == 'Running'"
+    - "postgres_pod['resources'][0]['status']['containerStatuses'][0]['ready'] == true"
+  delay: 5
+  retries: 60
+
+- name: Set the resource Pod name as a variable.
+  set_fact:
+    postgres_pod_name: "{{ postgres_pod['resources'][0]['metadata']['name'] }}"
+
+- name: Get the Service for the old Postgres Pod
+  k8s_info:
+    kind: Service
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    label_selectors:
+      - "app.kubernetes.io/component=database"
+      - "app.kubernetes.io/instance={{ old_postgres_pod.metadata.labels['app.kubernetes.io/instance'] }}"
+      - "app.kubernetes.io/managed-by={{ deployment_type }}-operator"
+  register: old_postgres_svc
+
+- name: Set full resolvable host name for Postgres Pod
+  set_fact:
+    resolvable_db_host: "{{ old_postgres_svc['resources'][0]['metadata']['name'] }}.{{ ansible_operator_meta.namespace }}.svc"  # yamllint disable-line rule:line-length
+  no_log: "{{ no_log }}"
+
+- name: Set pg_dump command
+  set_fact:
+    pg_dump: >-
+      pg_dump
+      -h {{ resolvable_db_host }}
+      -U {{ ansibleaiconnect_postgres_user }}
+      -d {{ ansibleaiconnect_postgres_database }}
+      -p {{ ansibleaiconnect_postgres_port }}
+      -F custom
+  no_log: "{{ no_log }}"
+
+- name: Set pg_restore command
+  set_fact:
+    pg_restore: >-
+      pg_restore
+      -U {{ ansibleaiconnect_postgres_user }}
+      -d {{ ansibleaiconnect_postgres_database }}
+  no_log: "{{ no_log }}"
+
+- name: Stream backup from pg_dump to the new Postgresql container
+  k8s_exec:
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    pod: "{{ postgres_pod_name }}"
+    command: |
+      bash -c "
+      function end_keepalive {
+        rc=$?
+        rm -f \"$1\"
+        kill $(cat /proc/$2/task/$2/children 2>/dev/null) 2>/dev/null || true
+        wait $2 || true
+        exit $rc
+      }
+      keepalive_file=\"$(mktemp)\"
+      while [[ -f \"$keepalive_file\" ]]; do
+        echo 'Migrating data to new PostgreSQL {{ supported_pg_version }} Database...'
+        sleep 60
+      done &
+      keepalive_pid=$!
+      trap 'end_keepalive \"$keepalive_file\" \"$keepalive_pid\"' EXIT SIGINT SIGTERM
+      echo keepalive_pid: $keepalive_pid
+      set -e -o pipefail
+      psql -c 'GRANT postgres TO {{ ansibleaiconnect_postgres_user }}'
+      PGPASSWORD=\"$POSTGRES_PASSWORD\" {{ pg_dump }} | PGPASSWORD=\"$POSTGRES_PASSWORD\" {{ pg_restore }}
+      psql -c 'REVOKE postgres FROM {{ ansibleaiconnect_postgres_user }}'
+      set +e +o pipefail
+      echo 'Successful'
+      "
+  no_log: "{{ no_log }}"
+  register: data_migration
+  failed_when: "'Successful' not in data_migration.stdout"
+
+- name: Set flag signifying that this instance has been migrated
+  set_fact:
+    upgraded_postgres_version: '{{ supported_pg_version }}'
+
+# ==============================================
+# Cleanup old Postgres resources
+# ----------------------------------------------
+# The old Postgres Pod name is included in the name of StatefulSet, PersistVolumeClaim and Service, e.g. 'postgres-13'
+- name: Get the name of the old Postgres Pod
+  set_fact:
+    old_postgres_pod_name: "{{ old_postgres_pod.metadata.labels['app.kubernetes.io/name'] }}"
+  no_log: "{{ no_log }}"
+
+- name: Remove old Postgres StatefulSet
+  k8s:
+    kind: StatefulSet
+    api_version: v1
+    name: "{{ ansible_operator_meta.name }}-{{ old_postgres_pod_name }}"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    state: absent
+    wait: true
+
+- name: Remove old Postgres Service
+  k8s:
+    kind: Service
+    api_version: v1
+    name: "{{ ansible_operator_meta.name }}-{{ old_postgres_pod_name }}"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    state: absent
+
+- name: Remove old PersistentVolumeClaim
+  k8s:
+    kind: PersistentVolumeClaim
+    api_version: v1
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    label_selectors:
+      - "app.kubernetes.io/instance={{ old_postgres_pod_name }}-{{ ansible_operator_meta.name }}"
+      - "app.kubernetes.io/managed-by={{ deployment_type }}-operator"
+    state: absent
+  when: not combined_database.postgres_keep_pvc_after_upgrade | bool
+# ==============================================

--- a/roles/postgres/templates/postgres_upgrade_secret.yaml.j2
+++ b/roles/postgres/templates/postgres_upgrade_secret.yaml.j2
@@ -1,0 +1,16 @@
+# Postgres Secret.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: '{{ ansible_operator_meta.name }}-postgres-configuration'
+  namespace: '{{ ansible_operator_meta.namespace }}'
+  labels:
+    {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(width=4) | trim }}
+stringData:
+  password: '{{ ansibleaiconnect_postgres_pass }}'
+  username: '{{ ansibleaiconnect_postgres_user }}'
+  database: '{{ ansibleaiconnect_postgres_database }}'
+  port: '{{ ansibleaiconnect_postgres_port }}'
+  host: '{{ ansible_operator_meta.name }}-postgres-{{ supported_pg_version }}'
+  type: 'managed'

--- a/roles/postgres/vars/main.yml
+++ b/roles/postgres/vars/main.yml
@@ -2,4 +2,6 @@
 # vars file for PostgreSQL database
 
 supported_pg_version: 15
+_previous_upgraded_pg_version: 0
 _postgres_data_path: '/var/lib/pgsql/data/userdata'
+old_postgres_pod: []


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-25066

**Testing**

- Uninstall any existing `AnsibleAIConnect` operator from your namespace
- Delete any existing `AAIC` instances from your namespace
- Delete any existing `PersistentVolumeClaim` instances from your namespace
- Edit `CatalogSource` to use `0.6.66-pr-186-202406100926` of the `AnsibleAIConnect` operator. This uses Postgres 13.
- When the `CatalogSource` is ready install the `AnsibleAIConnect` operator.
- Create an instance of `AAIC` and wait for it to be provisioned.

- Uninstall the `AnsibleAIConnect` operator. **DO NOT** delete the `AAIC` instance.
- Edit `CatalogSource` to use `0.6.66-pr-186-202406100923` of the `AnsibleAIConnect` operator. This uses Postgres 15.
- When the `CatalogSource` is ready install the `AnsibleAIConnect` operator.
- Watch and wait...
- The old `AAIC` instance will be scaled down.
- A new instance of Postgres (15) will be created.
- A new database `Secret` will be created for Postgres 15.
- A new `PersistenceVolumeClaim` will be created for Postgres 15.
- The `AAIC` deployment will be re-created.
- When things settle you can access the `Route` as normal.