### PR TITLE
AAP-25173: Rename model_name to model_id

### DIFF
--- a/docs/aap-wca-integrations.md
+++ b/docs/aap-wca-integrations.md
@@ -90,7 +90,7 @@ Currently, IBM watsonx Code Assistant can be delivered through a "cloud" version
 When you create a `Secret` for the Model configuration in the OpenShift cluster, the following pieces of information collected from the above will help:
 1. `model_url`: The URL to your Cloud Pack for Data instance 
 2. `model_api_key`: [Cloud Pack for Data API key](https://www.ibm.com/docs/en/cloud-paks/cp-data/4.8.x?topic=steps-generating-api-keys) 
-3. `model_name`: An e.g.: `8e7de79b-8bc2-43cc-9d20-c4207cd92fec<|sepofid|>granite-3b`
+3. `model_id`: An e.g.: `8e7de79b-8bc2-43cc-9d20-c4207cd92fec<|sepofid|>granite-3b`
 4. `username`: The username that has access to the model/space
 5. `model_type`: The literal value `"wca-onprem"`.
 
@@ -103,7 +103,7 @@ See [here](using-external-configuration-secrets.md#authentication-secret) for mo
 When you create a `Secret` for the Model configuration in the OpenShift cluster, the following pieces of information collected from the above will help:
 1. `model_url`: The URL to IBM Cloud `https://dataplatform.cloud.ibm.com`
 2. `model_api_key`: API key obtained from your IBM Cloud account
-3. `model_name`: An e.g.: `8e7de79b-8bc2-43cc-9d20-c4207cd92fec<|sepofid|>granite-3b`
+3. `model_id`: An e.g.: `8e7de79b-8bc2-43cc-9d20-c4207cd92fec<|sepofid|>granite-3b`
 4. `model_type`: The literal value `"wca"`.
 
 See [here](using-external-configuration-secrets.md#authentication-secret) for more instructions regarding configuration with `Secret`s.

--- a/docs/using-external-configuration-secrets.md
+++ b/docs/using-external-configuration-secrets.md
@@ -50,7 +50,7 @@ stringData:
   username: <WCA "on prem" username[1]>
   model_url: <WCA service URL>
   model_api_key: <WCA API Key>
-  model_name: <WCA Model Name>
+  model_id: <WCA Model Id>
   model_type: <WCA type[2]>
 type: Opaque
 ```
@@ -115,7 +115,7 @@ stringData:
   username: <WCA username>
   model_url: <WCA service URL>
   model_api_key: <WCA API Key>
-  model_name: <WCA Model Name>
+  model_id: <WCA Model Id>
   model_type: <WCA type>
 type: Opaque
 ```

--- a/molecule/default/tasks/2_0_model_config_test.yml
+++ b/molecule/default/tasks/2_0_model_config_test.yml
@@ -16,7 +16,7 @@
           - app.kubernetes.io/name = ansibleaiconnect-sample
       register: aiconnect_api_service
 
-    - name: Get original model_name
+    - name: Get original model_id
       uri:
         url: 'http://{{ service_host_ip }}:{{ service_host_port }}/check/status/'
         return_content: true
@@ -25,17 +25,17 @@
         service_host_port: '{{ aiconnect_api_service.resources[0].spec.ports[0].nodePort }}'
       register: service_host_response
 
-    - name: Assert original model_name response
+    - name: Assert original model_id response
       assert:
         that:
           - service_host_response.status == 200
           - service_host_response.json.status == 'ok'
-          - service_host_response.json.model_name == 'my-ai-model_name'
-        fail_msg: /check/status did not return expected model_name. Expected 'my-ai-model_name'.
+          - service_host_response.json.model_id== 'my-ai-model_id'
+        fail_msg: /check/status did not return expected model_id. Expected 'my-ai-model_id'.
 
     - include_tasks: 2_1_update_model_config_secret.yml
 
-    - name: Get updated model_name
+    - name: Get updated model_id
       uri:
         url: 'http://{{ service_host_ip }}:{{ service_host_port }}/check/status/'
         return_content: true
@@ -44,10 +44,10 @@
         service_host_port: '{{ aiconnect_api_service.resources[0].spec.ports[0].nodePort }}'
       register: updated_service_host_response
 
-    - name: Assert updated model_name response
+    - name: Assert updated model_id response
       assert:
         that:
         - updated_service_host_response.status == 200
         - updated_service_host_response.json.status == 'ok'
-        - updated_service_host_response.json.model_name == 'updated__my-ai-model_name'
-        fail_msg: /check/status did not return expected model_name. Expected 'updated__my-ai-model_name'.
+        - updated_service_host_response.json.model_id == 'updated__my-ai-model_id'
+        fail_msg: /check/status did not return expected model_id. Expected 'updated__my-ai-model_id'.

--- a/molecule/default/templates/secrets/model_config.secret.yaml.j2
+++ b/molecule/default/templates/secrets/model_config.secret.yaml.j2
@@ -8,6 +8,6 @@ data:
   username: 'dXNlcm5hbWU='
   model_url: 'aHR0cDovL215LWFpLWluc3RhbmNlLw=='
   model_api_key: 'bXktYWktYXBpLWtleQ=='
-  model_name: 'bXktYWktbW9kZWxfbmFtZQ=='
+  model_id: 'bXktYWktbW9kZWxfbmFtZQ=='
   model_type: 'd2NhLW9ucHJlbQ=='
 type: Opaque

--- a/molecule/default/templates/secrets/update_model_config.secret.yaml.j2
+++ b/molecule/default/templates/secrets/update_model_config.secret.yaml.j2
@@ -8,5 +8,5 @@ data:
   username: 'dXNlcm5hbWU='
   model_url: 'aHR0cDovL215LWFpLWluc3RhbmNlLw=='
   model_api_key: 'bXktYWktYXBpLWtleQ=='
-  model_name: 'dXBkYXRlZF9fbXktYWktbW9kZWxfbmFtZQ=='
+  model_id: 'dXBkYXRlZF9fbXktYWktbW9kZWxfbmFtZQ=='
 type: Opaque

--- a/roles/model/tasks/read_model_configuration_secret.yml
+++ b/roles/model/tasks/read_model_configuration_secret.yml
@@ -24,11 +24,11 @@
       You must specify a 'model_api_key' in your Secret.
   when: not _model_config_resource["resources"][0]["data"].model_api_key
 
-- name: Validate 'model_name'
+- name: Validate 'model_id'
   fail:
     msg: |
-      You must specify a 'model_name' in your Secret.
-  when: not _model_config_resource["resources"][0]["data"].model_name
+      You must specify a 'model_id' in your Secret.
+  when: not _model_config_resource["resources"][0]["data"].model_id
 
 - name: Validate 'model_type'
   fail:

--- a/roles/model/templates/model.deployment.yaml.j2
+++ b/roles/model/templates/model.deployment.yaml.j2
@@ -175,13 +175,13 @@ spec:
           valueFrom:
             secretKeyRef:
               name: '{{ model_config_secret_name }}'
-              key: model_name
+              key: model_id
         # Used by wisdom-service WCAClients
         - name: ANSIBLE_AI_MODEL_MESH_MODEL_NAME
           valueFrom:
             secretKeyRef:
               name: '{{ model_config_secret_name }}'
-              key: model_name
+              key: model_id
         - name: ANSIBLE_AI_MODEL_MESH_API_TYPE
           valueFrom:
             secretKeyRef:
@@ -196,7 +196,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: '{{ model_config_secret_name }}'
-              key: model_name
+              key: model_id
         - name: ANSIBLE_WCA_ONPREM_HEALTHCHECK_API_KEY
           valueFrom:
             secretKeyRef:
@@ -206,7 +206,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: '{{ model_config_secret_name }}'
-              key: model_name
+              key: model_id
         ports:
         - containerPort: 8000
           protocol: TCP


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-25173

This PR changes all `model_name` references & literals to `model_id`, including the model's secret `key`, and also the upstream docs (README's).

Tested in passive staging cluster (`stage2-west`), under my `romartin` namespace, by using the image for the PR build.

![Screenshot from 2024-06-10 21-59-11](https://github.com/ansible/ansible-ai-connect-operator/assets/4602417/e84e9153-28e5-4ef9-bf09-10cd8c92ec19)


