### PR TITLE
uwsgi: use the new package name

### DIFF
--- a/roles/model/templates/model.configmap.wisdom-service.yaml.j2
+++ b/roles/model/templates/model.configmap.wisdom-service.yaml.j2
@@ -25,7 +25,7 @@ data:
     lazy-apps = true
     skip-atexit = true
     manage-script-name = true
-    mount = /=ansible_wisdom.main.wsgi:application
+    mount = /=ansible_ai_connect.main.wsgi:application
 
     need-app = true                      ; Exit if no python application loaded
     harakiri = 60                        ; Forcefully kill workers after 60 seconds


### PR DESCRIPTION
We are in the process of renaming the `ansible_wisdom` package as `ansible_ai_connect`.
Right now we are exposing them both and we will later remove `ansible_wisdom` from the distribution.
