### PR TITLE
using ansible quay.io repo

### DIFF
--- a/.tekton/ansible-ai-connect-operator-pull-request.yaml
+++ b/.tekton/ansible-ai-connect-operator-pull-request.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ansible-lightspeed-tenant/ansible-ai-connect-operator/ansible-ai-connect-operator:on-pr-{{revision}}
+    value: quay.io/ansible/ansible-ai-connect-konflux:operator-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/ansible-ai-connect-operator-push.yaml
+++ b/.tekton/ansible-ai-connect-operator-push.yaml
@@ -22,7 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ansible-lightspeed-tenant/ansible-ai-connect-operator/ansible-ai-connect-operator:{{revision}}
+    value: quay.io/ansible/ansible-ai-connect-konflux:operator-{{revision}}
   - name: dockerfile
     value: /Dockerfile
   pipelineSpec:


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-24018

the `ansible-ai-connect-konflux` is still a temp repo while Konflux is wip