### PR TITLE
AAP-27719: Lightspeed on-prem using self-signed cert to connect to WCA-onprem failed

### DIFF
--- a/roles/model/templates/model.deployment.yaml.j2
+++ b/roles/model/templates/model.deployment.yaml.j2
@@ -189,6 +189,10 @@ spec:
             secretKeyRef:
               name: '{{ model_config_secret_name }}'
               key: model_id
+{% if bundle_ca_crt %}
+        - name: REQUESTS_CA_BUNDLE
+          value: "/etc/pki/tls/certs/ca-bundle.crt"
+{% endif %}
         ports:
         - containerPort: 8000
           protocol: TCP


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-27719

If a (self-signed) Certificate bundle has been provided ensure we configure `certifi` to use it (on RHEL).