### PR TITLE
AAP-30010: Document and Test on-prem Lightspeed API endpoint such that a customer could use in Tech Preview state

### DIFF
--- a/docs/user-guide/programmatic-api-use.md
+++ b/docs/user-guide/programmatic-api-use.md
@@ -12,6 +12,7 @@ In order to programmatically use the API an Access Token must be created.
 Username: admin
 Password: <password>
 ```
+- The Django Administration Portal is at `http[s]://<aaic-instance-route>/admin`
 - The password can be found in the `Secret` named `<aaic-instance-name>-admin-password` in the cluster namespace where the `AnsibleAIConnect` instance is deployed.
 
 2. In the Django Administration Portal, select "Users" from the "Users" area. 
@@ -20,6 +21,8 @@ Password: <password>
 
 
 3. Verify that the user to whom you want to grant programmatic access is in the Users list.
+
+NOTE: An access token can only be granted to an existing AAP User. The applicable User must first log into `Ansible AI Connect` with their credentials to create a User record in the Django database. Users created with `wisdom-manage createsuperuser` cannot be granted API access tokens.
 
 
 4. From the "Django Oauth toolkit" area, select "Access tokens" → "Add". 


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-30010

I followed the instructions on our `stage2-west` AAP 2.4 deployment and could successfully request a _completion_.