### PR TITLE
Auto-approve PRs for service version changes.

### DIFF
--- a/.github/workflows/auto-approve-version-changes.yaml
+++ b/.github/workflows/auto-approve-version-changes.yaml
@@ -1,0 +1,16 @@
+---
+name: Auto approve ansible-ai-connect-service version changes
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: ${{ startsWith(github.event.pull_request.title, '[Automated PR]') }}
+    steps:
+      - uses: hmarr/auto-approve-action@v4


### PR DESCRIPTION
See https://github.com/marketplace/actions/auto-approve

This *should* auto-approve PRs to bump `ansible-ai-connect-service` version changes.