### PR TITLE
AAP-43885: Lightspeed Operator: Correct Chatbot/Model CSV entries

### DIFF
--- a/config/manifests/bases/ansible-ai-connect-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ansible-ai-connect-operator.clusterserviceversion.yaml
@@ -361,12 +361,12 @@ spec:
         path: databaseConfigurationSecret
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:Secret
-      - description: ChatBot Configuration secret name of the deployed instance
-        displayName: ChatBot Configuration
+      - description: Model Configuration secret name of the deployed instance
+        displayName: Model Configuration
         path: modelConfigurationSecret
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:Secret
-      - description: Model Configuration secret name of the deployed instance
+      - description: Chatbot Configuration secret name of the deployed instance
         displayName: Chatbot Configuration
         path: chatbotConfigurationSecret
         x-descriptors:


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-43885

The Lightspeed Operator incorrectly labels the two Secret's for Model/Chatbot.

The "ChatBot Configuration" `displayName` is duplicated and the "descriptions" for `modelConfigurationSecret` and `chatbotConfigurationSecret` are wrong.

```
      - description: ChatBot Configuration secret name of the deployed instance
        displayName: ChatBot Configuration
        path: modelConfigurationSecret
        x-descriptors:
        - urn:alm:descriptor:io.kubernetes:Secret
      - description: Model Configuration secret name of the deployed instance
        displayName: Chatbot Configuration
        path: chatbotConfigurationSecret
        x-descriptors:
        - urn:alm:descriptor:io.kubernetes:Secret
```