### PR TITLE
AAP-44081: Remove status.conditions validation to allow auto-reporting errors on the CR statuses

### DIFF
--- a/config/crd/bases/aiconnect.ansible.com_ansibleaiconnects.yaml
+++ b/config/crd/bases/aiconnect.ansible.com_ansibleaiconnects.yaml
@@ -1000,6 +1000,7 @@ spec:
                 type: array
           status:
             description: Status defines the observed state of AnsibleAIConnect
+            x-kubernetes-preserve-unknown-fields: true
             properties:
               adminUser:
                 description: Admin user of the deployed instance
@@ -1040,20 +1041,6 @@ spec:
               URL:
                 description: URL to access the deployed instance
                 type: string
-              conditions:
-                description: The resulting conditions when a Service Telemetry is instantiated
-                items:
-                  properties:
-                    lastTransitionTime:
-                      type: string
-                    reason:
-                      type: string
-                    status:
-                      type: string
-                    type:
-                      type: string
-                  type: object
-                type: array
             type: object
         type: object
     served: true


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-44081

This replaces https://github.com/ansible/ansible-ai-connect-operator/pull/512 that was submitted incorrectly.

Remove `status.conditions` validation to allow auto-reporting errors on the CR statuses

* This allows the operator SDK to automatically set failed tasks in the operator logs as statuses on the CR
* This will make it easier for users to discover errors when debugging

Example status on the `AnsibleAIConnect` CR when there is a failed task:

```
  status:
    conditions:
    - lastTransitionTime: "2025-04-15T22:03:36Z"
      message: ""
      reason: ""
      status: "False"
      type: Successful
    - ansibleResult:
        changed: 0
        completion: "2025-04-15T22:04:03.499212+00:00"
        failures: 1
        ok: 2
        skipped: 1
      lastTransitionTime: "2025-04-15T22:03:36Z"
      message: |
        You must specify a value for 'model_config_secret_name'.
      reason: Failed
      status: "True"
      type: Failure
```

The trick was to get the CRD schema for `status.conditions` right, turns out it was excluding the conditions since the messages field was not explicitly defined.
