### PR TITLE
AAP-44914: Operator: Check Secret names exist

### DIFF
--- a/roles/chatbot/tasks/read_chatbot_configuration_secret.yml
+++ b/roles/chatbot/tasks/read_chatbot_configuration_secret.yml
@@ -8,6 +8,12 @@
   register: _chatbot_config_resource
   no_log: "{{ no_log }}"
 
+- name: Validate 'chatbot_config_secret_name'
+  ansible.builtin.fail:
+    msg: |
+      Secret {{ chatbot_config_secret_name }} could not be found.
+  when: _chatbot_config_resource["resources"] | length == 0
+
 # Validate Chatbot configuration
 - name: Validate 'chatbot_model'
   ansible.builtin.fail:

--- a/roles/model/tasks/read_auth_configuration_secret.yml
+++ b/roles/model/tasks/read_auth_configuration_secret.yml
@@ -9,6 +9,12 @@
       register: _auth_config_resource
       no_log: "{{ no_log }}"
 
+    - name: Validate 'auth_config_secret_name'
+      ansible.builtin.fail:
+        msg: |
+          Secret {{ auth_config_secret_name }} could not be found.
+      when: _auth_config_resource["resources"] | length == 0
+
     # Validate Authentication configuration
     - name: Validate 'auth_api_url'
       ansible.builtin.fail:

--- a/roles/model/tasks/read_model_configuration_secret.yml
+++ b/roles/model/tasks/read_model_configuration_secret.yml
@@ -9,6 +9,12 @@
       register: _model_config_resource
       no_log: "{{ no_log }}"
 
+    - name: Validate 'model_config_secret_name'
+      ansible.builtin.fail:
+        msg: |
+          Secret {{ model_config_secret_name }} could not be found.
+      when: _model_config_resource["resources"] | length == 0
+
     # Validate Model configuration
     - name: Validate 'model_url'
       ansible.builtin.fail:


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-44914

Testing:

With the following `AnsibleAIConnect` definition (and missing `Secret`'s):
```
apiVersion: aiconnect.ansible.com/v1alpha1
kind: AnsibleAIConnect
metadata:
  name: my-aiconnect
  namespace: ansible-ai-connect-operator-system
spec:
  ...
  auth_config_secret_name: 'my-secret-auth-configuration'
  model_config_secret_name: 'my-secret-model-configuration'
  chatbot_config_secret_name: 'my-secret-chatbot-configuration'
...
```

The following were observed and reflected in the CR {{status}}:
```
...
TASK [Validate 'auth_config_secret_name'] ******************************** 
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Secret my-secret-auth-configuration could not be found.\n"}
...
TASK [Validate 'model_config_secret_name'] ******************************** 
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Secret my-secret-model-configuration could not be found.\n"}
...
TASK [Validate 'chatbot_config_secret_name'] ******************************** 
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Secret my-secret-chatbot-configuration could not be found.\n"}
...
```
Creating the missing `Secret`'s one by one progressed deployment until it completed successfully.