### PR TITLE
AAP-45269: ability to disable SSL check between LS and the model

### DIFF
--- a/docs/aap-wca-integrations.md
+++ b/docs/aap-wca-integrations.md
@@ -3,6 +3,7 @@
 When deploying Ansible AI Connect service through operator, you will need to configure the integrations with Ansible Automation Platform and IBM watsonx Code Assistant. This is accomplished by providing `Secret`s with the necessary configuration details.
 
 ## Table of Contents
+
 - [Integrating with Ansible Automation Platform and IBM WCA](#integrating-with-ansible-automation-platform-and-ibm-wca)
   - [Table of Contents](#table-of-contents)
   - [Integrating with Ansible Automation Platform](#integrating-with-ansible-automation-platform)

--- a/docs/using-external-configuration-secrets.md
+++ b/docs/using-external-configuration-secrets.md
@@ -39,7 +39,7 @@ spec:
 
 ## Model service `Secret`
 
-`spec.model_config_secret_name` should be set to the name of an existing `Secret`. The Operator will use the values set therein to configure the model service integration. The `Secret` must contain the following values:
+`spec.model_config_secret_name` should be set to the name of an existing `Secret`. The Operator will use the values set there in to configure the model service integration. The `Secret` must contain the following values:
 ```yaml
 apiVersion: v1
 kind: Secret
@@ -52,10 +52,12 @@ stringData:
   model_api_key: <WCA API Key>
   model_id: <WCA Model Id>
   model_type: <WCA type[2]>
+  model_verify_ssl: <BOOL [3]>
 type: Opaque
 ```
 - [1] `username` is only required for `wca-onprem`. The value is discarded for `wca`.
-- [2] `model_type` is either `wca` or `wca-onprem`
+- [2] `model_type` is either `wca` or `wca-onprem`.
+- [3] `model_verify_ssl` is optional and defaults to True. Changing this value is discouraged.
 
 The `AnsibleAIConnect` configuration would look like this:
 ```yaml

--- a/molecule/default/tasks/2_0_model_config_test.yml
+++ b/molecule/default/tasks/2_0_model_config_test.yml
@@ -50,4 +50,5 @@
         - updated_service_host_response.status == 200
         - updated_service_host_response.json.status == 'ok'
         - updated_service_host_response.json.model_id == 'updated__my-ai-model_id'
+        - not updated_service_host_response.json.model_verify_ssl|bool
         fail_msg: /check/status did not return expected model_id. Expected 'updated__my-ai-model_id'.

--- a/molecule/default/tasks/3_0_model_pipeline_config_test.yml
+++ b/molecule/default/tasks/3_0_model_pipeline_config_test.yml
@@ -42,3 +42,9 @@
         that:
           - '"my-ai-model_name" in model_mesh_config'
         fail_msg: ANSIBLE_AI_MODEL_MESH_CONFIG did not contain expected model_id. Expected 'my-ai-model_id'.
+
+    - name: Assert verify_ssl is True by default
+      ansible.builtin.assert:
+        that:
+          - '"verify_ssl: True" in model_mesh_config'
+        fail_msg: ANSIBLE_AI_MODEL_MESH_CONFIG doesn't have verify_ssl enabled by default.

--- a/molecule/default/templates/secrets/update_model_config.secret.yaml.j2
+++ b/molecule/default/templates/secrets/update_model_config.secret.yaml.j2
@@ -9,4 +9,5 @@ data:
   model_url: 'aHR0cDovL215LWFpLWluc3RhbmNlLw=='
   model_api_key: 'bXktYWktYXBpLWtleQ=='
   model_id: 'dXBkYXRlZF9fbXktYWktbW9kZWxfbmFtZQ=='
+  model_verify_ssl: 'ZmFsc2U='
 type: Opaque

--- a/roles/model/tasks/read_model_configuration_secret.yml
+++ b/roles/model/tasks/read_model_configuration_secret.yml
@@ -74,7 +74,7 @@
         no_log: "{{ no_log }}"
       when: model_type == 'wca-onprem'
 
-    - name: Set Model 'model_idp_url'
+    - name: Set model 'model_idp_url'
       ansible.builtin.set_fact:
         model_idp_url: '{{ _model_config_resource["resources"][0]["data"].model_idp_url | b64decode }}'
       no_log: "{{ no_log }}"
@@ -82,6 +82,15 @@
         - model_type == 'wca'
         - _model_config_resource["resources"][0]["data"].model_idp_url is defined
         - _model_config_resource["resources"][0]["data"].model_idp_url | length
+
+    - name: Set model 'verify_ssl'
+      ansible.builtin.set_fact:
+        model_verify_ssl: '{{ _model_config_resource["resources"][0]["data"].model_verify_ssl | b64decode | bool }}'
+      no_log: "{{ no_log }}"
+      when:
+        - _model_config_resource["resources"][0]["data"].model_verify_ssl is defined
+        - _model_config_resource["resources"][0]["data"].model_verify_ssl | length
+
 
     - name: Set AI Configuration
       ansible.builtin.set_fact:

--- a/roles/model/templates/secrets/model_pipeline_config.yaml.j2
+++ b/roles/model/templates/secrets/model_pipeline_config.yaml.j2
@@ -42,6 +42,7 @@ stringData:
         inference_url: '{{ model_url }}'
         api_key: '{{ model_api_key }}'
         model_id: '{{ model_id }}'
+        verify_ssl: {{ model_verify_ssl | default(True) }}
         timeout: 15
         enable_health_check: 'True'
         health_check_api_key: '{{ model_api_key }}'
@@ -58,6 +59,7 @@ stringData:
         inference_url: '{{ model_url }}'
         api_key: '{{ model_api_key }}'
         model_id: '{{ model_id }}'
+        verify_ssl: {{ model_verify_ssl | default(True) }}
         timeout: 15
         enable_health_check: 'True'
         health_check_api_key: '{{ model_api_key }}'
@@ -74,6 +76,7 @@ stringData:
         inference_url: '{{ model_url }}'
         api_key: '{{ model_api_key }}'
         model_id: '{{ model_id }}'
+        verify_ssl: {{ model_verify_ssl | default(True) }}
         timeout: 15
         enable_health_check: 'True'
         health_check_api_key: '{{ model_api_key }}'
@@ -90,6 +93,7 @@ stringData:
         inference_url: '{{ model_url }}'
         api_key: '{{ model_api_key }}'
         model_id: '{{ model_id }}'
+        verify_ssl: {{ model_verify_ssl | default(True) }}
         timeout: 15
         enable_health_check: 'True'
         health_check_api_key: '{{ model_api_key }}'
@@ -108,6 +112,7 @@ stringData:
         inference_url: '{{ model_url }}'
         api_key: '{{ model_api_key }}'
         model_id: '{{ model_id }}'
+        verify_ssl: {{ model_verify_ssl | default(True) }}
         timeout: 15
         enable_health_check: 'True'
         health_check_api_key: '{{ model_api_key }}'
@@ -126,6 +131,7 @@ stringData:
         inference_url: '{{ model_url }}'
         api_key: '{{ model_api_key }}'
         model_id: '{{ model_id }}'
+        verify_ssl: {{ model_verify_ssl | default(True) }}
         timeout: 15
         enable_health_check: 'True'
         health_check_api_key: '{{ model_api_key }}'


### PR DESCRIPTION
Add a new configuration key called `model_verify_ssl` to disable the SSL
verification between the model and the Lightspeed service.
