### PR TITLE
AAP-45583: Lightspeed Operator should allow watsonx as an LLM provider

### DIFF
--- a/docs/using-external-configuration-secrets.md
+++ b/docs/using-external-configuration-secrets.md
@@ -87,6 +87,7 @@ stringData:
   chatbot_model: <Chatbot model name>
   chatbot_token: <Chatbot LLM access token>
   chatbot_llm_provider_type: <Chatbot LLM provider type>
+  chatbot_llm_provider_project_id: <Chatbot LLM provider project id>
   chatbot_context_window_size: <Chatbot LLM context window size>
   chatbot_temperature_override: <Chatbot LLM temperature parameter>
 type: Opaque
@@ -104,6 +105,9 @@ following default values will be used:
 
 * `chatbot_llm_provider_type`: `rhoai_vllm`
 * `chatbot_context_window_size`: `128000`
+
+When `chatbot_llm_provider_type` is set to `watsonx`,
+`chatbot_llm_provider_project_id` is required to set to your watsonx.ai project ID.
 
 `chatbot_temperature_override` is also optional.  It is provided for 
 following Open AI models that do not support the default temperature setting used for

--- a/roles/chatbot/tasks/read_chatbot_configuration_secret.yml
+++ b/roles/chatbot/tasks/read_chatbot_configuration_secret.yml
@@ -18,7 +18,7 @@
 - name: Validate 'chatbot_model'
   ansible.builtin.fail:
     msg: |
-      You must specify an 'chatbot_model' in your Secret.
+      You must specify a 'chatbot_model' in your Secret.
   when: not _chatbot_config_resource["resources"][0]["data"].chatbot_model
 
 - name: Set Chatbot model
@@ -29,7 +29,7 @@
 - name: Validate 'chatbot_url'
   ansible.builtin.fail:
     msg: |
-      You must specify an 'chatbot_url' in your Secret.
+      You must specify a 'chatbot_url' in your Secret.
   when: not _chatbot_config_resource["resources"][0]["data"].chatbot_url
 
 - name: Set Chatbot URL
@@ -40,7 +40,7 @@
 - name: Validate 'chatbot_token'
   ansible.builtin.fail:
     msg: |
-      You must specify an 'chatbot_token' in your Secret.
+      You must specify a 'chatbot_token' in your Secret.
   when: not _chatbot_config_resource["resources"][0]["data"].chatbot_token
 
 - name: Set Chatbot Configuration
@@ -53,6 +53,21 @@
     chatbot_llm_provider_type: '{{ _chatbot_config_resource["resources"][0]["data"].chatbot_llm_provider_type | b64decode }}'
   no_log: "{{ no_log }}"
   when: _chatbot_config_resource["resources"][0]["data"].chatbot_llm_provider_type is defined
+
+- name: Validate watsonx.ai project ID if LLM provider type is set to "watsonx"
+  ansible.builtin.fail:
+    msg: |
+      You must specify a 'chatbot_llm_provider_project_id' in your Secret when 'chatbot_llm_provider_type' is set to 'watsonx'
+  when:
+    - chatbot_llm_provider_type is defined
+    - chatbot_llm_provider_type == "watsonx"
+    - not _chatbot_config_resource["resources"][0]["data"].chatbot_llm_provider_project_id is defined
+
+- name: Set watsonx.ai project ID if it is defined in the config
+  ansible.builtin.set_fact:
+    chatbot_llm_provider_project_id: '{{ _chatbot_config_resource["resources"][0]["data"].chatbot_llm_provider_project_id | b64decode }}'
+  no_log: "{{ no_log }}"
+  when: _chatbot_config_resource["resources"][0]["data"].chatbot_llm_provider_project_id is defined
 
 - name: Set context window size if it is defined in the config
   ansible.builtin.set_fact:

--- a/roles/chatbot/templates/chatbot.configmap.yaml.j2
+++ b/roles/chatbot/templates/chatbot.configmap.yaml.j2
@@ -16,6 +16,9 @@ data:
         type: {{ chatbot_llm_provider_type | default('rhoai_vllm') }}
         url: {{ chatbot_url }}
         credentials_path: /app-root/keys1/chatbot-token.txt
+{% if chatbot_llm_provider_project_id is defined %}
+        project_id: {{ chatbot_llm_provider_project_id }}
+{% endif %}
         models:
           - name: {{ chatbot_model }}
             context_window_size: {{ chatbot_context_window_size | default(128000) }}


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-45583

A new charbot secret key `chatbot_llm_provider_project_id` is added for a watsonx.ai project ID, which is required when `chatbot_llm_provider_type` is set to `watsonx`.