### PR TITLE
AAP-43385: On-prem: Automate provision and related configuration changes. Fix ModelPipeline configuration.

### DIFF
--- a/roles/model/templates/secrets/model_pipeline_config.yaml.j2
+++ b/roles/model/templates/secrets/model_pipeline_config.yaml.j2
@@ -23,11 +23,17 @@ stringData:
 {% endif %}
         model_id: '{{ chatbot_model }}'
         enable_health_check: 'True'
+{% if _aap_gateway_url is defined or _aap_controller_url is defined %}
         mcp_servers:
+{% if _aap_gateway_url is defined and _aap_controller_url is defined %}
           - name: 'mcp::aap-controller'
             type: 'controller'
+{% endif %}
+{% if _aap_gateway_url is defined %}
           - name: 'mcp::aap-lightspeed'
             type: 'lightspeed'
+{% endif %}
+{% endif %}
       provider: 'http'
     ModelPipelineStreamingChatBot:
       config:
@@ -39,11 +45,17 @@ stringData:
 {% endif %}
         model_id: '{{ chatbot_model }}'
         enable_health_check: 'True'
+{% if _aap_gateway_url is defined or _aap_controller_url is defined %}
         mcp_servers:
+{% if _aap_gateway_url is defined and _aap_controller_url is defined %}
           - name: 'mcp::aap-controller'
             type: 'controller'
+{% endif %}
+{% if _aap_gateway_url is defined %}
           - name: 'mcp::aap-lightspeed'
             type: 'lightspeed'
+{% endif %}
+{% endif %}
       provider: 'http'
 {% endif %}
 {% if model_config is defined %}


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-43385

## Description
This PR fixes the `chatbot.deployment.yaml.j2` template.

The `mcp_servers` section is now only generated if the MCP related URLs have been set.

## Testing
1. Deploy the Operator somewhere.
2. Configure it _as normal_ for the Chatbot.
3. Omit parameters for `aap_gateway_url` and `aap_controller_url`.
4. The generated `xxx-model-pipeline-configuration` `Secret` **should not** include `mcp_servers`.
5. Add additional parameters for `aap_gateway_url` and `aap_controller_url`.
6. The generated `xxx-model-pipeline-configuration` `Secret` **should** include `mcp_servers`.

### Scenarios tested
As above.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
