### PR TITLE
Fix provider_id's to be consistent.

### DIFF
--- a/roles/chatbot/templates/chatbot.configmap_llama_stack_config.yaml.j2
+++ b/roles/chatbot/templates/chatbot.configmap_llama_stack_config.yaml.j2
@@ -21,7 +21,7 @@ data:
       - tool_runtime
     providers:
       inference:
-        - provider_id: my_rhoai_dev
+        - provider_id: rhoai
           provider_type: remote::vllm
           config:
             url: ${env.VLLM_URL}
@@ -88,7 +88,7 @@ data:
     models:
       - metadata: {}
         model_id: ${env.INFERENCE_MODEL}
-        provider_id: my_rhoai_dev
+        provider_id: rhoai
         provider_model_id: null
       - metadata:
           embedding_dimension: 768

--- a/roles/model/templates/model.deployment.yaml.j2
+++ b/roles/model/templates/model.deployment.yaml.j2
@@ -95,9 +95,6 @@ spec:
       - name: model-api
         image: {{ _image }}
         imagePullPolicy: "{{ image_pull_policy }}"
-        envFrom:
-          - configMapRef:
-              name: "{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties"
         env:
 {% if auth_config is defined %}
         - name: AAP_API_URL
@@ -167,8 +164,11 @@ spec:
               key: config
 {% if chatbot_config is defined %}
         - name: CHATBOT_DEFAULT_PROVIDER
-          value: "default_provider"
+          value: "rhoai"
 {% endif %}
+        envFrom:
+          - configMapRef:
+              name: "{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties"
         ports:
         - containerPort: 8000
           protocol: TCP


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
During testing of AAP 2.6 Nightly builds we discovered that the `provider_id`'s were inconsistent.

This led to `lightspeed-stack` reporting it was unable to find a `provider_id`/`model_id` to match the requests.

## Testing
N/A

### Steps to test
N/A

### Scenarios tested
N/A

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This PR should be released in 2.4 (cherry-pick should be created)
- [ ] This PR should be released in 2.5 (cherry-pick should be created)
- [ ] This code change requires the following considerations before going to production:
