### PR TITLE
Fix MCP Server URLs

### DIFF
--- a/roles/chatbot/templates/chatbot.configmap_llama_stack_config.yaml.j2
+++ b/roles/chatbot/templates/chatbot.configmap_llama_stack_config.yaml.j2
@@ -112,13 +112,13 @@ data:
       - toolgroup_id: mcp::aap-controller
         provider_id: model-context-protocol
         mcp_endpoint:
-          uri: http://localhost:8004/sse
+          uri: http://127.0.0.1:8004/sse
 {% endif %}
 {% if _aap_gateway_url is defined %}
       - toolgroup_id: mcp::aap-lightspeed
         provider_id: model-context-protocol
         mcp_endpoint:
-          uri: http://localhost:8005/sse
+          uri: http://127.0.0.1:8005/sse
 {% endif %}
     logging: null
     server:


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
The MCP Server URLs in both `llama-stack` and `lightspeed-stack` configuration need to be identical. Doh.

## Testing
N/A

 ### Steps to test
N/A

### Scenarios tested
N/A

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This PR should be released in 2.4 (cherry-pick should be created)
- [ ] This PR should be released in 2.5 (cherry-pick should be created)
- [ ] This code change requires the following considerations before going to production:
