### PR TITLE
AAP-49049: Update update-ca-trust command for RHEL9 compatibility

### DIFF
--- a/roles/chatbot/templates/chatbot.deployment.yaml.j2
+++ b/roles/chatbot/templates/chatbot.deployment.yaml.j2
@@ -68,7 +68,7 @@ spec:
           - -c
           - |
             mkdir -p /etc/pki/ca-trust/extracted/{java,pem,openssl,edk2}
-            update-ca-trust
+            update-ca-trust extract --output /etc/pki/ca-trust/extracted
 {% if combined_chatbot_api.resource_requirements is defined %}
         resources: {{ combined_chatbot_api.resource_requirements }}
 {% endif %}

--- a/roles/model/templates/model.deployment.yaml.j2
+++ b/roles/model/templates/model.deployment.yaml.j2
@@ -79,7 +79,7 @@ spec:
           - -c
           - |
             mkdir -p /etc/pki/ca-trust/extracted/{java,pem,openssl,edk2}
-            update-ca-trust
+            update-ca-trust extract --output /etc/pki/ca-trust/extracted
 {% if combined_api.resource_requirements is defined %}
         resources: {{ combined_api.resource_requirements }}
 {% endif %}


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-49049>

## Description
After image base upgrade from RHEL8 to RHEL 9 we got CA certs broken.

Root cause: https://gitlab.com/redhat/centos-stream/rpms/ca-certificates/-/commit/81a090f89a413487bb8a8677eff9bb4fb8bfbf71. Due to moving to RHEL9 base, the update-ca-trust script has changed and it requires to use '--extract  --output /etc/pki/ca-trust/extracted' parameters. That will make the script to chown the folders in order to be able to make the symbolic links within directory-hash folder.

See jira for more details.

## Testing
After this fix installation is good with or without using custom certificates


## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This PR should be released in 2.4 (cherry-pick should be created)
- [ ] This PR should be released in 2.5 (cherry-pick should be created)
- [x] This PR should be released in 2.6 (cherry-pick should be created)
- [ ] This code change requires the following considerations before going to production: None
