### PR TITLE
add knowledge_search to always_include_tools for filter agent

### DIFF
--- a/roles/chatbot/templates/chatbot.configmap_llama_stack_config.yaml.j2
+++ b/roles/chatbot/templates/chatbot.configmap_llama_stack_config.yaml.j2
@@ -59,6 +59,8 @@ data:
             tools_filter:
               enabled: true
               model_id: ${env.INFERENCE_MODEL_FILTER:=}
+              always_include_tools:
+              - knowledge_search
       datasetio:
         - provider_id: localfs
           provider_type: inline::localfs


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue:  https://issues.redhat.com/browse/AAP-52354
<!-- This PR does not need a corresponding Jira item. -->

## Description
add knowledge_search to always_include_tools for filter agent, this will allow rag tool knowledge_search to be always available and not filtered out. Note the default min tools to start filtering is 10 , so even if the filter is enabled,
 and we have less than 10 tools the filtering will not happen.
 see: https://github.com/lightspeed-core/lightspeed-providers/tree/main/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent

Related: https://github.com/ansible/ansible-chatbot-stack/pull/96


### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This PR should be released in 2.4 (cherry-pick should be created)
- [ ] This PR should be released in 2.5 (cherry-pick should be created)
- [ ] This code change requires the following considerations before going to production:
