### PR TITLE
Add postgres extra settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .cache/
 bin
 testbin/*
+hacking/
 /bundle
 /bundle_tmp*
 /bundle.Dockerfile

--- a/config/crd/bases/aiconnect.ansible.com_ansibleaiconnects.yaml
+++ b/config/crd/bases/aiconnect.ansible.com_ansibleaiconnects.yaml
@@ -176,10 +176,25 @@ spec:
                     description: Customize the postgres init container commands (Non Openshift)
                     type: string
                   postgres_extra_args:
-                    description: Arguments to pass to postgres process
+                    description: (Deprecated, use postgres_extra_settings parameter) Arguments to pass to postgres process
                     items:
                       type: string
                     type: array
+                  postgres_extra_settings:
+                    description: "PostgreSQL configuration settings to be added to postgresql.conf"
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        setting:
+                          description: "PostgreSQL configuration parameter name"
+                          type: string
+                        value:
+                          description: "PostgreSQL configuration parameter value"
+                          type: string
+                      required:
+                        - setting
+                        - value
                   priority_class:
                     description: Assign a pre-existing priority class to the postgres pod
                     type: string

--- a/config/manifests/bases/ansible-ai-connect-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ansible-ai-connect-operator.clusterserviceversion.yaml
@@ -204,8 +204,13 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - displayName: Database Extra Arguments
+      - displayName: Database Extra Arguments (Deprecated)
         path: database.postgres_extra_args
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Database Extra Settings
+        path: database.postgres_extra_settings
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden

--- a/docs/user-guide/database-configuration.md
+++ b/docs/user-guide/database-configuration.md
@@ -79,10 +79,12 @@ spec:
       requests:
         storage: 8Gi
     postgres_storage_class: fast-ssd
-    postgres_extra_args:
-      - '-c'
-      - 'max_connections=1000'
+    postgres_extra_settings:
+      - setting: max_connections
+        value: 1000
 ```
+
+> **Note**: The `postgres_extra_args` parameter is deprecated. Use `postgres_extra_settings` instead to configure PostgreSQL parameters through the postgresql.conf file.
 
 **Note**: If `database.postgres_storage_class` is not defined, PostgreSQL will store it's data on a volume using the default storage class for your cluster.
 

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -49,7 +49,8 @@ _database:
   node_selector: ''
   tolerations: ''
   priority_class: ''
-  postgres_extra_args: ''
+  postgres_extra_args: ''  # Deprecated
+  postgres_extra_settings: []  # Define postgresql.conf configurations
   postgres_keep_pvc_after_upgrade: true  # Specify whether or not to keep the old PVC after PostgreSQL upgrades
   postgres_data_volume_init: false
   postgres_init_container_commands: |

--- a/roles/postgres/tasks/create_managed_postgres.yml
+++ b/roles/postgres/tasks/create_managed_postgres.yml
@@ -7,6 +7,12 @@
     postgres_label_selector: "app.kubernetes.io/instance=postgres-{{ supported_pg_version }}-{{ ansible_operator_meta.name }}"
   when: postgres_label_selector is not defined
 
+- name: Create postgresql.conf ConfigMap
+  kubernetes.core.k8s:
+    apply: true
+    definition: "{{ lookup('template', 'postgres.configmap.yaml.j2') }}"
+  when: combined_database.postgres_extra_settings | length
+
 - name: Create database Service
   kubernetes.core.k8s:
     apply: yes

--- a/roles/postgres/templates/postgres.configmap.yaml.j2
+++ b/roles/postgres/templates/postgres.configmap.yaml.j2
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: '{{ ansible_operator_meta.name }}-postgres-extra-settings'
+  namespace: '{{ ansible_operator_meta.namespace }}'
+  labels:
+    app.kubernetes.io/name: 'postgres-extra-settings-{{ supported_pg_version }}'
+    app.kubernetes.io/instance: 'postgres-{{ supported_pg_version }}-{{ ansible_operator_meta.name }}'
+    app.kubernetes.io/component: 'database'
+    app.kubernetes.io/part-of: '{{ ansible_operator_meta.name }}'
+    app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+data:
+  99-overrides.conf: |
+{% for pg_setting in combined_database.postgres_extra_settings %}
+{% if pg_setting.value is string %}
+    {{ pg_setting.setting }} = '{{ pg_setting.value }}'
+{% else %}
+    {{ pg_setting.setting }} = {{ pg_setting.value }}
+{% endif %}
+{% endfor %}

--- a/roles/postgres/templates/postgres.statefulset.yaml.j2
+++ b/roles/postgres/templates/postgres.statefulset.yaml.j2
@@ -29,6 +29,11 @@ spec:
         app.kubernetes.io/component: 'database'
         app.kubernetes.io/part-of: '{{ ansible_operator_meta.name }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+      annotations:
+{% if combined_database.postgres_extra_settings | length > 0 %}
+        checksum-configmap-postgres_extra_settings: "{{ lookup('template', 'postgres.configmap.yaml.j2') | sha1 }}"
+{% endif %}
+        checksum-secret-postgres_configuration_secret: "{{ lookup('ansible.builtin.vars', 'pg_config', default='')['resources'][0]['data'] | default('') | sha1 }}"
     spec:
       securityContext:
         allowPrivilegeEscalation: false
@@ -126,8 +131,22 @@ spec:
             - name: postgres-{{ supported_pg_version }}
               mountPath: '{{ _postgres_data_path | dirname }}'
               subPath: '{{ _postgres_data_path | dirname | basename }}'
+{% if combined_database.postgres_extra_settings | length > 0 %}
+            - name: pg-overrides
+              mountPath: /opt/app-root/src/postgresql-cfg
+              readOnly: true
+{% endif %}
 {% if combined_database.resource_requirements is defined %}
           resources: {{ combined_database.resource_requirements }}
+{% endif %}
+{% if combined_database.postgres_extra_settings | length > 0 %}
+      volumes:
+        - name: pg-overrides
+          configMap:
+            name: '{{ ansible_operator_meta.name }}-postgres-extra-settings'
+            items:
+              - key: 99-overrides.conf
+                path: 99-overrides.conf
 {% endif %}
   volumeClaimTemplates:
     - metadata:


### PR DESCRIPTION
Jira Issue: [AAP-52282](https://issues.redhat.com/browse/AAP-52282)

## Description
Add postgres_extra_settings to add configurations to postgresql.conf on managed postgres deployments

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Create a CR with the database setting `postgres_extra_settings` under spec for example:
```
spec:
  database:
    postgres_extra_settings:
      - setting: max_connections
        value: '1000'
```
3. Connect to the postgresql pod and verify with:
`psql -c "SELECT name,setting FROM pg_settings WHERE name = 'max_connections';"`
4. Change `max_connections` to 999 and apply the CR
5. Verify the postgresql pod cycles and the latest setting is applied from the query in step 3 

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This PR should be released in 2.4 (cherry-pick should be created)
- [ ] This PR should be released in 2.5 (cherry-pick should be created)
- [ ] This code change requires the following considerations before going to production:
