### PR TITLE
Add HMAC key, installer id and internal email domains for telemetry

### DIFF
--- a/molecule/default/tasks/6_0_mcpserver_config_test.yml
+++ b/molecule/default/tasks/6_0_mcpserver_config_test.yml
@@ -31,3 +31,69 @@
         - service_host_response.status == 200
         - service_host_response.json.status == 'ok'
         fail_msg: /check endpoint did not return expected response. Expected HTTP200, OK.
+
+    - name: Get telemetry HMAC key secret
+      kubernetes.core.k8s_info:
+        kind: Secret
+        name: ansiblemcpconnect-sample-telemetry-hmac-secret
+        namespace: '{{ namespace }}'
+      register: telemetry_hmac_secret
+
+    - name: Assert telemetry HMAC key secret exists
+      ansible.builtin.assert:
+        that:
+          - telemetry_hmac_secret.resources | length == 1
+        fail_msg: Telemetry HMAC key secret was not created.
+
+    - name: Assert telemetry HMAC key secret contains expected key
+      ansible.builtin.assert:
+        that:
+          - "'telemetry_hmac_key' in telemetry_hmac_secret.resources[0].data"
+        fail_msg: Telemetry HMAC key secret does not contain 'telemetry_hmac_key' data key.
+
+    - name: Assert telemetry HMAC key is 64 characters (256-bit hex)
+      ansible.builtin.assert:
+        that:
+          - (telemetry_hmac_secret.resources[0].data.telemetry_hmac_key | b64decode | length) == 64
+        fail_msg: Telemetry HMAC key is not 64 characters long.
+
+    - name: Get MCP Server deployment
+      kubernetes.core.k8s_info:
+        kind: Deployment
+        namespace: '{{ namespace }}'
+        label_selectors:
+          - app.kubernetes.io/name = ansiblemcpconnect-sample
+      register: mcpserver_deployment
+
+    - name: Assert TELEMETRY_HMAC_KEY env var is set in deployment
+      ansible.builtin.assert:
+        that:
+          - mcpserver_deployment.resources[0].spec.template.spec.containers[0].env | selectattr('name', 'equalto', 'TELEMETRY_HMAC_KEY') | list | length > 0
+        fail_msg: TELEMETRY_HMAC_KEY environment variable is not set in MCP Server deployment.
+
+    - name: Get MCP Server ConfigMap
+      kubernetes.core.k8s_info:
+        kind: ConfigMap
+        name: ansiblemcpconnect-sample-ansible-mcp-connect-env-properties
+        namespace: '{{ namespace }}'
+      register: mcpserver_configmap
+
+    - name: Assert ConfigMap exists
+      ansible.builtin.assert:
+        that:
+          - mcpserver_configmap.resources | length == 1
+        fail_msg: MCP Server ConfigMap was not created.
+
+    - name: Assert INSTALLER_ID is set in ConfigMap
+      ansible.builtin.assert:
+        that:
+          - "'INSTALLER_ID' in mcpserver_configmap.resources[0].data"
+          - mcpserver_configmap.resources[0].data.INSTALLER_ID | length > 0
+        fail_msg: INSTALLER_ID is not set in MCP Server ConfigMap.
+
+    - name: Assert INTERNAL_EMAIL_DOMAINS is set in ConfigMap
+      ansible.builtin.assert:
+        that:
+          - "'INTERNAL_EMAIL_DOMAINS' in mcpserver_configmap.resources[0].data"
+          - "'redhat.com' in mcpserver_configmap.resources[0].data.INTERNAL_EMAIL_DOMAINS"
+        fail_msg: INTERNAL_EMAIL_DOMAINS is not set correctly in MCP Server ConfigMap.

--- a/roles/mcpserver/defaults/main.yml
+++ b/roles/mcpserver/defaults/main.yml
@@ -126,6 +126,23 @@ service_annotations: ''
 
 
 # ========================================
+# Internal Email Domains
+# ----------------------------------------
+# Comma-separated list of email domains considered "internal" for user_type classification.
+internal_email_domains: 'redhat.com,ibm.com,ansible.com'
+# ----------------------------------------
+
+
+# ========================================
+# Telemetry HMAC Key
+# ----------------------------------------
+# Secret to lookup that provides the telemetry HMAC key for pseudonym generation.
+# If empty, a secret will be auto-generated on first deployment.
+telemetry_hmac_secret: ''
+# ----------------------------------------
+
+
+# ========================================
 # Custom CA Certificates
 # ----------------------------------------
 # Secret to lookup that provides the custom CA trusted bundle

--- a/roles/mcpserver/tasks/installer_id_configuration.yml
+++ b/roles/mcpserver/tasks/installer_id_configuration.yml
@@ -1,0 +1,19 @@
+---
+- name: Check for existing ConfigMap with INSTALLER_ID
+  kubernetes.core.k8s_info:
+    kind: ConfigMap
+    namespace: '{{ ansible_operator_meta.namespace }}'
+    name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties'
+  register: _existing_configmap
+
+- name: Extract existing INSTALLER_ID if present
+  ansible.builtin.set_fact:
+    __installer_id: "{{ _existing_configmap['resources'][0]['data']['INSTALLER_ID'] }}"
+  when:
+    - _existing_configmap['resources'] | default([]) | length
+    - "'INSTALLER_ID' in _existing_configmap['resources'][0]['data']"
+
+- name: Generate new INSTALLER_ID if not present
+  ansible.builtin.set_fact:
+    __installer_id: "{{ lookup('password', '/dev/null length=36 chars=hexdigits') | lower | regex_replace('(.{8})(.{4})(.{4})(.{4})(.{12})', '\\1-\\2-\\3-\\4-\\5') }}"
+  when: __installer_id is not defined

--- a/roles/mcpserver/tasks/main.yml
+++ b/roles/mcpserver/tasks/main.yml
@@ -26,6 +26,12 @@
     - ingress_type | lower == 'route'
     - route_tls_secret | length
 
+- name: Configure telemetry HMAC key
+  ansible.builtin.include_tasks: telemetry_hmac_configuration.yml
+
+- name: Configure installer ID
+  ansible.builtin.include_tasks: installer_id_configuration.yml
+
 - name: Deploy MCP Server API service
   ansible.builtin.include_tasks: deploy_mcpserver_api.yml
 

--- a/roles/mcpserver/tasks/telemetry_hmac_configuration.yml
+++ b/roles/mcpserver/tasks/telemetry_hmac_configuration.yml
@@ -1,0 +1,48 @@
+---
+- name: Check for custom telemetry HMAC key secret
+  kubernetes.core.k8s_info:
+    kind: Secret
+    namespace: '{{ ansible_operator_meta.namespace }}'
+    name: '{{ telemetry_hmac_secret }}'
+  register: _custom_telemetry_hmac
+  no_log: "{{ no_log }}"
+  when: telemetry_hmac_secret | length
+
+- name: Check for existing telemetry HMAC key secret
+  kubernetes.core.k8s_info:
+    kind: Secret
+    namespace: '{{ ansible_operator_meta.namespace }}'
+    name: '{{ ansible_operator_meta.name }}-telemetry-hmac-secret'
+  register: _existing_telemetry_hmac
+  no_log: "{{ no_log }}"
+
+- name: Set telemetry HMAC key secret
+  ansible.builtin.set_fact:
+    _telemetry_hmac_secret: '{{ _custom_telemetry_hmac["resources"] | default([]) | length | ternary(_custom_telemetry_hmac, _existing_telemetry_hmac) }}'
+  no_log: "{{ no_log }}"
+
+- block:
+    - name: Create telemetry HMAC key secret
+      kubernetes.core.k8s:
+        apply: true
+        definition: "{{ lookup('template', 'secrets/telemetry_hmac_key.yaml.j2') }}"
+      no_log: "{{ no_log }}"
+
+    - name: Read telemetry HMAC key secret
+      kubernetes.core.k8s_info:
+        kind: Secret
+        namespace: '{{ ansible_operator_meta.namespace }}'
+        name: '{{ ansible_operator_meta.name }}-telemetry-hmac-secret'
+      register: _generated_telemetry_hmac
+      no_log: "{{ no_log }}"
+  when: not _telemetry_hmac_secret['resources'] | default([]) | length
+
+- name: Set telemetry HMAC key secret
+  ansible.builtin.set_fact:
+    telemetry_hmac: '{{ _generated_telemetry_hmac["resources"] | default([]) | length | ternary(_generated_telemetry_hmac, _telemetry_hmac_secret) }}'
+  no_log: "{{ no_log }}"
+
+- name: Store telemetry HMAC key secret name
+  ansible.builtin.set_fact:
+    __telemetry_hmac_secret_name: "{{ telemetry_hmac['resources'][0]['metadata']['name'] }}"
+  no_log: "{{ no_log }}"

--- a/roles/mcpserver/templates/mcpserver.configmap.yaml.j2
+++ b/roles/mcpserver/templates/mcpserver.configmap.yaml.j2
@@ -9,6 +9,8 @@ metadata:
     {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(width=4) | trim }}
 data:
   BASE_URL: "{{ public_base_url }}"
+  INSTALLER_ID: "{{ __installer_id }}"
+  INTERNAL_EMAIL_DOMAINS: "{{ internal_email_domains }}"
 {% if allow_write_operations is defined %}
   ALLOW_WRITE_OPERATIONS: "{{ allow_write_operations }}"
 {% endif %}

--- a/roles/mcpserver/templates/mcpserver.deployment.yaml.j2
+++ b/roles/mcpserver/templates/mcpserver.deployment.yaml.j2
@@ -138,6 +138,11 @@ spec:
         - name: SERVICE_CA_PATH
           value: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
 {% endif %}
+        - name: TELEMETRY_HMAC_KEY
+          valueFrom:
+            secretKeyRef:
+              name: '{{ __telemetry_hmac_secret_name }}'
+              key: telemetry_hmac_key
         envFrom:
           - configMapRef:
               name: "{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties"

--- a/roles/mcpserver/templates/secrets/telemetry_hmac_key.yaml.j2
+++ b/roles/mcpserver/templates/secrets/telemetry_hmac_key.yaml.j2
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: '{{ ansible_operator_meta.name }}-telemetry-hmac-secret'
+  namespace: '{{ ansible_operator_meta.namespace }}'
+  labels:
+    app.kubernetes.io/name: '{{ ansible_operator_meta.name }}'
+    app.kubernetes.io/part-of: '{{ ansible_operator_meta.name }}'
+    app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+    app.kubernetes.io/component: '{{ deployment_type }}'
+    app.kubernetes.io/operator-version: '{{ lookup("env", "OPERATOR_VERSION") }}'
+stringData:
+  telemetry_hmac_key: '{{ lookup("password", "/dev/null length=64 chars=hexdigits") }}'


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://redhat.atlassian.net/browse/AAP-68798 and https://redhat.atlassian.net/browse/AAP-70090
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->

- Add HMAC key, installer id and internal email domains for telemetry.
- Add molecule test to validate the changes.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Deploy the operator on a cluster
3. Run it a validate the new properties for telemetry


## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This PR should be released in 2.4 (cherry-pick should be created)
- [ ] This PR should be released in 2.5 (cherry-pick should be created)
- [ ] This PR should be released in 2.6 (cherry-pick should be created)
- [ ] This code change requires the following considerations before going to production:
