### PR TITLE
Specify explicit ownerReferences to prevent reconciliation loops

### DIFF
--- a/molecule/default/tasks/9_0_token_cleanup_cronjobs_test.yml
+++ b/molecule/default/tasks/9_0_token_cleanup_cronjobs_test.yml
@@ -20,6 +20,20 @@
           revoke-expired-refreshtokens CronJob is not configured correctly.
           Got: {{ revoke_cronjob.resources }}
 
+    - name: Assert revoke-expired-refreshtokens CronJob has correct ownerReferences
+      ansible.builtin.assert:
+        that:
+          - revoke_cronjob.resources[0].metadata.ownerReferences | length == 1
+          - revoke_cronjob.resources[0].metadata.ownerReferences[0].kind == "AnsibleAIConnect"
+          - revoke_cronjob.resources[0].metadata.ownerReferences[0].name == "ansibleaiconnect-sample"
+          - revoke_cronjob.resources[0].metadata.ownerReferences[0].blockOwnerDeletion == false
+          - revoke_cronjob.resources[0].metadata.ownerReferences[0].controller is not defined or
+            revoke_cronjob.resources[0].metadata.ownerReferences[0].controller == false
+        fail_msg: >-
+          revoke-expired-refreshtokens CronJob ownerReferences not configured correctly.
+          Setting controller=true would cause reconciliation loops.
+          Got: {{ revoke_cronjob.resources[0].metadata.ownerReferences }}
+
     - name: Get cleartokens CronJob
       kubernetes.core.k8s_info:
         namespace: '{{ namespace }}'
@@ -39,3 +53,17 @@
         fail_msg: >-
           cleartokens CronJob is not configured correctly.
           Got: {{ cleartokens_cronjob.resources }}
+
+    - name: Assert cleartokens CronJob has correct ownerReferences
+      ansible.builtin.assert:
+        that:
+          - cleartokens_cronjob.resources[0].metadata.ownerReferences | length == 1
+          - cleartokens_cronjob.resources[0].metadata.ownerReferences[0].kind == "AnsibleAIConnect"
+          - cleartokens_cronjob.resources[0].metadata.ownerReferences[0].name == "ansibleaiconnect-sample"
+          - cleartokens_cronjob.resources[0].metadata.ownerReferences[0].blockOwnerDeletion == false
+          - cleartokens_cronjob.resources[0].metadata.ownerReferences[0].controller is not defined or
+            cleartokens_cronjob.resources[0].metadata.ownerReferences[0].controller == false
+        fail_msg: >-
+          cleartokens CronJob ownerReferences not configured correctly.
+          Setting controller=true would cause reconciliation loops.
+          Got: {{ cleartokens_cronjob.resources[0].metadata.ownerReferences }}

--- a/roles/model/tasks/deploy_token_cleanup_cronjobs.yml
+++ b/roles/model/tasks/deploy_token_cleanup_cronjobs.yml
@@ -1,4 +1,24 @@
 ---
+- name: Get current CR details for ownerReferences
+  kubernetes.core.k8s_info:
+    api_version: "{{ api_version }}"
+    kind: "{{ kind }}"
+    name: "{{ ansible_operator_meta.name }}"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+  register: _cr_info
+
+- name: Verify CR exists
+  ansible.builtin.assert:
+    that:
+      - _cr_info.resources | length > 0
+    fail_msg: "Failed to find AnsibleAIConnect/{{ ansible_operator_meta.name }} CR"
+
+- name: Set CR facts for ownerReferences
+  ansible.builtin.set_fact:
+    _cr_uid: "{{ _cr_info.resources[0].metadata.uid }}"
+    api_version: "{{ _cr_info.resources[0].apiVersion }}"
+    kind: "{{ _cr_info.resources[0].kind }}"
+
 - name: Apply token cleanup CronJob resources
   kubernetes.core.k8s:
     apply: yes

--- a/roles/model/tasks/deploy_token_cleanup_cronjobs.yml
+++ b/roles/model/tasks/deploy_token_cleanup_cronjobs.yml
@@ -16,8 +16,6 @@
 - name: Set CR facts for ownerReferences
   ansible.builtin.set_fact:
     _cr_uid: "{{ _cr_info.resources[0].metadata.uid }}"
-    api_version: "{{ _cr_info.resources[0].apiVersion }}"
-    kind: "{{ _cr_info.resources[0].kind }}"
 
 - name: Apply token cleanup CronJob resources
   kubernetes.core.k8s:

--- a/roles/model/templates/model.cronjob.token-cleanup.yaml.j2
+++ b/roles/model/templates/model.cronjob.token-cleanup.yaml.j2
@@ -8,6 +8,16 @@ metadata:
     app.kubernetes.io/component: '{{ deployment_type }}-token-cleanup'
   name: '{{ ansible_operator_meta.name }}-cronjob-{{ _cronjob_name }}'
   namespace: '{{ ansible_operator_meta.namespace }}'
+  # Explicit ownerReferences without controller=true prevents reconciliation loops.
+  # CronJob status updates (every 5min for revoke-tokens) would otherwise trigger
+  # full operator reconciliation (~3min), creating an infinite loop.
+  # Setting ownerReferences manually still ensures garbage collection on CR deletion.
+  ownerReferences:
+    - apiVersion: {{ api_version }}
+      kind: {{ kind }}
+      name: {{ ansible_operator_meta.name }}
+      uid: {{ _cr_uid }}
+      blockOwnerDeletion: false
 spec:
   schedule: "{{ _cronjob_schedule }}"
   concurrencyPolicy: Forbid


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://redhat.atlassian.net/browse/AAP-70702
<!-- This PR does not need a corresponding Jira item. -->

Assisted-by: Claude Code
Generated by: Claude Code

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
Specify explicit ownerReferences without `controller=true` to prevent reconciliation loops to resolve the issue that majority of the OCP fresh installation pipelines are failing to deploy AAP.  The changes made here are based on the first suggestion found in the OCP logs:
```
Root cause: The new CronJobs (from the backport-cronjob commits linked below) have ownerReferences to the AnsibleLightspeed CR, causing an infinite reconciliation loop. Every 5 minutes
  revoke-tokens fires, updates the CronJob status, operator-sdk sees the owned resource change, triggers re-reconciliation, which takes ~3 minutes, and by then the next CronJob fires.

  The fix would be to either:
  1. Remove ownerReferences from the CronJobs (set them manually without ownership)
  2. Or use watchDependentResources: false in watches.yaml to stop watching owned resources (but that affects all owned resources)
```

## Testing
Molecule test case is provided in this PR.

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This PR should be released in 2.4 (cherry-pick should be created)
- [ ] This PR should be released in 2.5 (cherry-pick should be created)
- [ ] This PR should be released in 2.6 (cherry-pick should be created)
- [ ] This code change requires the following considerations before going to production:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Kubernetes resource ownership/metadata for CronJobs, which can affect garbage collection and reconciliation behavior, but the change is narrowly scoped and covered by a molecule assertion.
> 
> **Overview**
> Prevents infinite operator reconcile loops triggered by token-cleanup CronJob status updates by **explicitly setting `metadata.ownerReferences` without `controller=true`** on the generated CronJobs.
> 
> The deploy task now fetches the CR UID and injects it into the CronJob template, and the molecule scenario adds assertions verifying the expected `ownerReferences` and that `controller` is unset/false.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67cbe523dc52ca9083730caa7bd2fc6cfcd2fea1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->