### PR TITLE
Wire chatbot and llama-stack storage to existing PostgreSQL

### DIFF
--- a/config/crd/bases/aiconnect.ansible.com_ansibleaiconnects.yaml
+++ b/config/crd/bases/aiconnect.ansible.com_ansibleaiconnects.yaml
@@ -118,6 +118,21 @@ spec:
               chatbot_config_secret_name:
                 description: "Secret where the chatbot configuration can be found"
                 type: string
+              chatbot_transcripts_enabled:
+                description: "Enable file-based conversation transcript exports in the chatbot. Transcripts are written as JSON files to an ephemeral volume. Conversation metadata is always persisted in the database regardless of this setting. Default: false"
+                type: boolean
+                default: false
+              chatbot_feedback_enabled:
+                description: "Enable user feedback collection in the chatbot. Feedback is written as JSON files to an ephemeral volume. Default: false"
+                type: boolean
+                default: false
+              chatbot_user_data_storage_class:
+                description: "Storage class for the chatbot transcript and feedback file PVC. When set, a PersistentVolumeClaim is created for persistent file exports. When empty, an emptyDir volume is used."
+                type: string
+              chatbot_user_data_storage_size:
+                description: "Size of the chatbot transcript and feedback file volume. Used as PVC request when storage class is set, or emptyDir sizeLimit otherwise. Default: 1Gi"
+                type: string
+                default: "1Gi"
               chatbot_extra_settings:
                 type: object
                 description: "Chatbot Dynamic dictionary for extra settings"

--- a/config/manifests/bases/ansible-ai-connect-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ansible-ai-connect-operator.clusterserviceversion.yaml
@@ -85,6 +85,28 @@ spec:
         path: chatbot_mcp_lightspeed_image_version
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: Enable file-based conversation transcript exports in the chatbot
+        displayName: Chatbot Transcripts Enabled
+        path: chatbot_transcripts_enabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Enable user feedback collection in the chatbot
+        displayName: Chatbot Feedback Enabled
+        path: chatbot_feedback_enabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Storage class for persistent transcript and feedback file exports.
+          When set, a PersistentVolumeClaim is created.
+        displayName: Chatbot User Data Storage Class
+        path: chatbot_user_data_storage_class
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:io.kubernetes:StorageClass
+      - description: Size of the chatbot transcript and feedback file volume
+        displayName: Chatbot User Data Storage Size
+        path: chatbot_user_data_storage_size
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: Chatbot extra settings key-value pairs.
         displayName: Chatbot Extra Settings
         path: chatbot_extra_settings

--- a/roles/chatbot/defaults/main.yml
+++ b/roles/chatbot/defaults/main.yml
@@ -40,6 +40,21 @@ _chatbot_mcp_lightspeed_image_version: "{{ lookup('env', 'DEFAULT_CHATBOT_MCP_LI
 # Configuration for Chatbot provider
 # ----------------------------------------
 chatbot_config_secret_name: ''
+
+# ----------------------------------------
+# User data collection settings
+# ----------------------------------------
+chatbot_transcripts_enabled: false
+chatbot_feedback_enabled: false
+
+# ----------------------------------------
+# Transcript/feedback file storage
+# ----------------------------------------
+# When chatbot_user_data_storage_class is set, a PVC is created for
+# persistent file-based transcript and feedback exports.
+# Otherwise an emptyDir volume is used.
+chatbot_user_data_storage_class: ''
+chatbot_user_data_storage_size: '1Gi'
 # ========================================
 
 

--- a/roles/chatbot/tasks/deploy_chatbot_api.yml
+++ b/roles/chatbot/tasks/deploy_chatbot_api.yml
@@ -1,4 +1,13 @@
 ---
+- name: Apply Chatbot user data PVC
+  kubernetes.core.k8s:
+    apply: yes
+    definition: "{{ lookup('template', 'chatbot.pvc_user_data.yaml.j2') }}"
+    wait: no
+  when:
+    - chatbot_user_data_storage_class is defined
+    - chatbot_user_data_storage_class | length > 0
+
 - name: Apply Chatbot deployment resources
   kubernetes.core.k8s:
     apply: yes

--- a/roles/chatbot/templates/chatbot.configmap_lightspeed_stack_config.yaml.j2
+++ b/roles/chatbot/templates/chatbot.configmap_lightspeed_stack_config.yaml.j2
@@ -30,9 +30,22 @@ data:
     llama_stack:
       use_as_library_client: true
       library_client_config_path: /.llama/distributions/llama-stack/config/ansible-chatbot-run.yaml
+    database:
+      postgres:
+        host: {{ ansibleaiconnect_postgres_host }}
+        port: {{ ansibleaiconnect_postgres_port }}
+        db: {{ ansibleaiconnect_postgres_database }}
+        user: {{ ansibleaiconnect_postgres_user }}
+        password: {{ ansibleaiconnect_postgres_pass }}
     user_data_collection:
-      feedback_enabled: false
-      transcripts_enabled: false
+      feedback_enabled: {{ chatbot_feedback_enabled | default(false) | bool | lower }}
+{% if chatbot_feedback_enabled | default(false) | bool %}
+      feedback_storage: /.llama/data/user-data/feedback
+{% endif %}
+      transcripts_enabled: {{ chatbot_transcripts_enabled | default(false) | bool | lower }}
+{% if chatbot_transcripts_enabled | default(false) | bool %}
+      transcripts_storage: /.llama/data/user-data/transcripts
+{% endif %}
     customization:
       system_prompt_path: /.llama/distributions/ansible-chatbot/system-prompts/default.txt
 {% if _chatbot_byok_image is defined %}

--- a/roles/chatbot/templates/chatbot.configmap_llama_stack_config.yaml.j2
+++ b/roles/chatbot/templates/chatbot.configmap_llama_stack_config.yaml.j2
@@ -106,11 +106,20 @@ data:
           type: kv_sqlite
           db_path: ${env.VECTOR_DB_DIR:=/.llama/data/distributions/ansible-chatbot}/aap_faiss_store.db
         kv_default:
-          type: kv_sqlite
-          db_path: ${env.KV_STORE_DB_DIR:=/.llama/data/distributions/ansible-chatbot}/kv_store.db
+          type: kv_postgres
+          host: {{ ansibleaiconnect_postgres_host }}
+          port: {{ ansibleaiconnect_postgres_port }}
+          db: {{ ansibleaiconnect_postgres_database }}
+          user: {{ ansibleaiconnect_postgres_user }}
+          password: {{ ansibleaiconnect_postgres_pass }}
+          table_name: llamastack_kvstore
         sql_default:
-          type: sql_sqlite
-          db_path: ${env.SQL_STORE_DB_DIR:=/.llama/data/distributions/ansible-chatbot}/sql_store.db
+          type: sql_postgres
+          host: {{ ansibleaiconnect_postgres_host }}
+          port: {{ ansibleaiconnect_postgres_port }}
+          db: {{ ansibleaiconnect_postgres_database }}
+          user: {{ ansibleaiconnect_postgres_user }}
+          password: {{ ansibleaiconnect_postgres_pass }}
       stores:
         metadata:
           namespace: registry

--- a/roles/chatbot/templates/chatbot.deployment.yaml.j2
+++ b/roles/chatbot/templates/chatbot.deployment.yaml.j2
@@ -171,6 +171,10 @@ spec:
             mountPath: /.llama/distributions/llama-stack/config
           - name: ansible-chatbot-system-prompt
             mountPath: /.llama/distributions/ansible-chatbot/system-prompts
+{% if chatbot_transcripts_enabled | default(false) | bool or chatbot_feedback_enabled | default(false) | bool %}
+          - name: ansible-chatbot-user-data
+            mountPath: /.llama/data/user-data
+{% endif %}
 {% if is_openshift %}
           - name: lm-stack-tls-certs
             mountPath: /app-root/certs/
@@ -308,6 +312,16 @@ spec:
         - name: ansible-chatbot-byok-storage
           emptyDir:
             sizeLimit: '{{ _chatbot_byok_storage_size }}'
+{% endif %}
+{% if chatbot_transcripts_enabled | default(false) | bool or chatbot_feedback_enabled | default(false) | bool %}
+        - name: ansible-chatbot-user-data
+{% if chatbot_user_data_storage_class is defined and chatbot_user_data_storage_class | length %}
+          persistentVolumeClaim:
+            claimName: '{{ ansible_operator_meta.name }}-chatbot-user-data'
+{% else %}
+          emptyDir:
+            sizeLimit: '{{ chatbot_user_data_storage_size | default("1Gi") }}'
+{% endif %}
 {% endif %}
 {% if is_openshift %}
         - name: lm-stack-tls-certs

--- a/roles/chatbot/templates/chatbot.pvc_user_data.yaml.j2
+++ b/roles/chatbot/templates/chatbot.pvc_user_data.yaml.j2
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: '{{ ansible_operator_meta.name }}-chatbot-user-data'
+  namespace: '{{ ansible_operator_meta.namespace }}'
+  labels:
+    {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(width=4) | trim }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+{% if chatbot_user_data_storage_class is defined and chatbot_user_data_storage_class | length %}
+  storageClassName: '{{ chatbot_user_data_storage_class }}'
+{% endif %}
+  resources:
+    requests:
+      storage: '{{ chatbot_user_data_storage_size | default("1Gi") }}'


### PR DESCRIPTION
## Summary

The chatbot uses ephemeral SQLite databases for all persistent state, causing conversation history to be lost on pod restart. The operator already provisions a PostgreSQL database whose credentials are available as Ansible facts from the postgres role.

Conversation data is stored in two layers — both were using SQLite on emptyDir volumes:

| Layer | Tables | What it stores |
|-------|--------|---------------|
| **Llama Stack** (`public` schema) | `openai_conversations`, `conversation_items` | Actual conversation messages |
| **Lightspeed Stack** (`lightspeed-stack` schema) | `user_conversation`, `user_turn` | Sidebar metadata (conversation list, timestamps, topic summaries) |

Reference: [lightspeed-core/lightspeed-stack database model](https://github.com/lightspeed-core/lightspeed-stack/blob/main/src/models/database/conversations.py) and [conversations API docs](https://github.com/lightspeed-core/lightspeed-stack/blob/main/docs/conversations_api.md)

### Changes

- **Lightspeed Stack → PostgreSQL**: Adds a `database.postgres` block to the chatbot configmap template using existing `ansibleaiconnect_postgres_*` facts from the postgres role.

- **Llama Stack → PostgreSQL**: Switches `kv_default` and `sql_default` storage backends from `kv_sqlite`/`sql_sqlite` to `kv_postgres`/`sql_postgres`. The `kv_rag` backend stays as SQLite since it holds ephemeral RAG vector data populated by the init container on every pod start.

- **Configurable transcripts and feedback**: Exposes `chatbot_transcripts_enabled` and `chatbot_feedback_enabled` as CR spec fields (both default to `false`). These control file-based JSON exports — separate from core database persistence.

- **Optional PVC for file exports**: Adds `chatbot_user_data_storage_class` and `chatbot_user_data_storage_size` CR fields. When a storage class is specified, a PVC is created for persistent transcript/feedback files. Otherwise an emptyDir is used.

### Design

```
Conversation messages (always persisted)
  └─ Llama Stack → sql_default (sql_postgres) → existing PostgreSQL
  
Conversation metadata / sidebar (always persisted)
  └─ Lightspeed Stack → database.postgres → existing PostgreSQL

RAG vector data (ephemeral, rebuilt on pod start)
  └─ Llama Stack → kv_rag (kv_sqlite) → emptyDir

Transcript/feedback file exports (opt-in via CR fields)
  └─ PVC (when storage class set) or emptyDir (default)
```

Closes #734

## Test plan

- [ ] Deploy operator with default CR — verify conversations persist across pod restarts (both sidebar list and message content)
- [ ] Check PostgreSQL tables: `lightspeed-stack.user_conversation`, `public.openai_conversations`, `public.conversation_items` are populated
- [ ] Verify RAG search still works (kv_rag on emptyDir is rebuilt by init container)
- [ ] Enable `chatbot_transcripts_enabled: true` without storage class — verify JSON files written to emptyDir
- [ ] Enable `chatbot_transcripts_enabled: true` with `chatbot_user_data_storage_class` — verify PVC created