### PR TITLE
Fix BYOK init container UID mismatch on AKS

### DIFF
--- a/roles/chatbot/templates/chatbot.deployment.yaml.j2
+++ b/roles/chatbot/templates/chatbot.deployment.yaml.j2
@@ -98,6 +98,8 @@ spec:
 {% if _chatbot_byok_image is defined %}
       - name: init-byok-vector-db
         image: '{{ _chatbot_byok_image }}'
+        securityContext:
+          runAsUser: 1001
         env:
           - name: BYOK_CONFIG_CHATBOT_DIR
             value: /.llama/data/byok/distributions/ansible-chatbot


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://redhat.atlassian.net/browse/AAP-71601
<!-- This PR does not need a corresponding Jira item. -->

## Description
Add securityContext to init-byok-vector-db container to run as uid=1001, matching the main chatbot container user.

This fixes an issue on Azure Kubernetes Service where the BYOK init container creates files owned by uid=65532 (the BYOK image default), which the main container (uid=1001) cannot write to, causing SQLite 'attempt to write a readonly database' errors.

The fix ensures files are created with the correct ownership from the start, allowing the chatbot to start successfully with BYOK enabled.

Platforms like OpenShift and AWS EKS automatically handle this via SCCs or admission controllers, but AKS requires explicit configuration.

Resolves: BYOK fails on AKS with readonly database error

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. ...
3. ...

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [ ] This code change is ready for production on its own
- [ ] This PR should be released in 2.4 (cherry-pick should be created)
- [ ] This PR should be released in 2.5 (cherry-pick should be created)
- [ ] This PR should be released in 2.6 (cherry-pick should be created)
- [ ] This code change requires the following considerations before going to production:
