### PR TITLE
feat: add proxy env var support for AnsibleAIConnect containers

### DIFF
--- a/config/crd/bases/aiconnect.ansible.com_ansibleaiconnects.yaml
+++ b/config/crd/bases/aiconnect.ansible.com_ansibleaiconnects.yaml
@@ -1027,6 +1027,15 @@ spec:
               bundle_cacert_secret:
                 description: Secret where the trusted Certificate Authority Bundle is stored
                 type: string
+              http_proxy:
+                description: HTTP proxy URL to configure on AnsibleAIConnect containers
+                type: string
+              https_proxy:
+                description: HTTPS proxy URL to configure on AnsibleAIConnect containers
+                type: string
+              no_proxy:
+                description: Comma-separated list of hosts that bypass the proxy on AnsibleAIConnect containers
+                type: string
               db_fields_encryption_secret:
                 description: Secret where the DB fields encryption key can be found. If not specified, one will be generated.
                 type: string

--- a/config/crd/bases/mcpconnect.ansible.com_ansiblemcpconnects.yaml
+++ b/config/crd/bases/mcpconnect.ansible.com_ansiblemcpconnects.yaml
@@ -477,6 +477,15 @@ spec:
               bundle_cacert_secret:
                 description: Secret where the trusted Certificate Authority Bundle is stored
                 type: string
+              http_proxy:
+                description: HTTP proxy URL to configure on AnsibleMCPConnect containers
+                type: string
+              https_proxy:
+                description: HTTPS proxy URL to configure on AnsibleMCPConnect containers
+                type: string
+              no_proxy:
+                description: Comma-separated list of hosts that bypass the proxy on AnsibleMCPConnect containers
+                type: string
               set_self_labels:
                 description: Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
                 type: boolean

--- a/config/manifests/bases/ansible-ai-connect-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ansible-ai-connect-operator.clusterserviceversion.yaml
@@ -349,6 +349,24 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
+      - description: HTTP proxy URL to configure on AI Connect containers
+        displayName: HTTP Proxy
+        path: http_proxy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: HTTPS proxy URL to configure on AI Connect containers
+        displayName: HTTPS Proxy
+        path: https_proxy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Comma-separated list of hosts that bypass the proxy on AI Connect containers
+        displayName: No Proxy
+        path: no_proxy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Name of the k8s secret the DB fields encryption key is stored
           in.
         displayName: DB Fields Encryption Key
@@ -627,6 +645,24 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
+      - description: HTTP proxy URL to configure on MCP Connect containers
+        displayName: HTTP Proxy
+        path: http_proxy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: HTTPS proxy URL to configure on MCP Connect containers
+        displayName: HTTPS Proxy
+        path: https_proxy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Comma-separated list of hosts that bypass the proxy on MCP Connect containers
+        displayName: No Proxy
+        path: no_proxy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
       - displayName: AAP Gateway URL
         path: aap_gateway_url
         x-descriptors:

--- a/roles/chatbot/defaults/main.yml
+++ b/roles/chatbot/defaults/main.yml
@@ -58,3 +58,15 @@ _chatbot_api:
       memory: "5000Mi"
   # Explicit parameters
 # ========================================
+
+
+# ========================================
+# Proxy environment variables for chatbot containers.
+# Defaults inherit from the operator pod environment (e.g. set by the OCP cluster
+# proxy object). Set these fields in the CR spec to override the inherited values
+# per instance.
+# ----------------------------------------
+http_proxy: "{{ lookup('env', 'http_proxy') or lookup('env', 'HTTP_PROXY') or '' }}"
+https_proxy: "{{ lookup('env', 'https_proxy') or lookup('env', 'HTTPS_PROXY') or '' }}"
+no_proxy: "{{ lookup('env', 'no_proxy') or lookup('env', 'NO_PROXY') or '' }}"
+# ========================================

--- a/roles/chatbot/templates/chatbot.deployment.yaml.j2
+++ b/roles/chatbot/templates/chatbot.deployment.yaml.j2
@@ -38,6 +38,9 @@ spec:
         checksum-configmap-chatbot-llama-stack-config: "{{ lookup('template', 'chatbot.configmap_llama_stack_config.yaml.j2') | sha1 }}"
         checksum-configmap-chatbot-system-prompt: "{{ lookup('template', 'chatbot.configmap_system_prompt.yaml.j2') | sha1 }}"
         checksum-secret-chatbot_config: "{{ lookup('ansible.builtin.vars', 'chatbot_config', default='')["resources"][0]["data"] | default('') | sha1 }}"
+{% if http_proxy or https_proxy or no_proxy %}
+        checksum-proxy-env-configmap: "{{ lookup('template', '../common/templates/proxy-env.configmap.yaml.j2') | sha1 }}"
+{% endif %}
     spec:
       serviceAccountName: '{{ ansible_operator_meta.name }}'
       # Pod-level security context
@@ -155,6 +158,10 @@ spec:
             value: {{ chatbot_model }}
           - name: INFERENCE_MODEL_FILTER
             value: {{ chatbot_model }}
+        envFrom:
+          - configMapRef:
+              name: '{{ ansible_operator_meta.name }}-proxy-env'
+              optional: true
         ports:
 {% if is_openshift %}
           - containerPort: 8443
@@ -218,6 +225,10 @@ spec:
             value: {{ _aap_gateway_url }}
           - name: AAP_SERVICE_URL
             value: {{ _aap_controller_url }}
+        envFrom:
+          - configMapRef:
+              name: '{{ ansible_operator_meta.name }}-proxy-env'
+              optional: true
         ports:
           - containerPort: 8004
             protocol: TCP
@@ -258,6 +269,10 @@ spec:
             value: {{ _aap_gateway_url }}
           - name: AAP_SERVICE_URL
             value: {{ _aap_lightspeed_url }}
+        envFrom:
+          - configMapRef:
+              name: '{{ ansible_operator_meta.name }}-proxy-env'
+              optional: true
         ports:
           - containerPort: 8005
             protocol: TCP

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -30,3 +30,9 @@
 
 - name: Patch Labels
   ansible.builtin.include_tasks: patch_labels.yml
+
+- name: Apply proxy environment ConfigMap
+  kubernetes.core.k8s:
+    apply: yes
+    definition: "{{ lookup('template', 'proxy-env.configmap.yaml.j2') }}"
+    state: "{{ 'present' if (http_proxy or https_proxy or no_proxy) else 'absent' }}"

--- a/roles/common/templates/proxy-env.configmap.yaml.j2
+++ b/roles/common/templates/proxy-env.configmap.yaml.j2
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: '{{ ansible_operator_meta.name }}-proxy-env'
+  namespace: '{{ ansible_operator_meta.namespace }}'
+data:
+{% if http_proxy %}
+  HTTP_PROXY: '{{ http_proxy }}'
+  http_proxy: '{{ http_proxy }}'
+{% endif %}
+{% if https_proxy %}
+  HTTPS_PROXY: '{{ https_proxy }}'
+  https_proxy: '{{ https_proxy }}'
+{% endif %}
+{% if no_proxy %}
+  NO_PROXY: '{{ no_proxy }}'
+  no_proxy: '{{ no_proxy }}'
+{% endif %}

--- a/roles/mcpserver/defaults/main.yml
+++ b/roles/mcpserver/defaults/main.yml
@@ -149,6 +149,18 @@ telemetry_hmac_secret: ''
 bundle_cacert_secret: ''
 # ----------------------------------------
 
+
+# ========================================
+# Proxy environment variables for mcpserver containers.
+# Defaults inherit from the operator pod environment (e.g. set by the OCP cluster
+# proxy object). Set these fields in the CR spec to override the inherited values
+# per instance.
+# ----------------------------------------
+http_proxy: "{{ lookup('env', 'http_proxy') or lookup('env', 'HTTP_PROXY') or '' }}"
+https_proxy: "{{ lookup('env', 'https_proxy') or lookup('env', 'HTTPS_PROXY') or '' }}"
+no_proxy: "{{ lookup('env', 'no_proxy') or lookup('env', 'NO_PROXY') or '' }}"
+# ========================================
+
 # ========================================
 # Unused by AnsibleMCPConnect
 # ----------------------------------------

--- a/roles/mcpserver/templates/mcpserver.deployment.yaml.j2
+++ b/roles/mcpserver/templates/mcpserver.deployment.yaml.j2
@@ -39,6 +39,9 @@ spec:
   ] %}
         checksum-{{ template | replace('/', '-') }}: "{{ lookup('template', template + '.yaml.j2') | sha1 }}"
 {% endfor %}
+{% if http_proxy or https_proxy or no_proxy %}
+        checksum-proxy-env-configmap: "{{ lookup('template', '../common/templates/proxy-env.configmap.yaml.j2') | sha1 }}"
+{% endif %}
     spec:
       serviceAccountName: '{{ ansible_operator_meta.name }}'
 {% if image_pull_secrets | length > 0 %}
@@ -146,6 +149,9 @@ spec:
         envFrom:
           - configMapRef:
               name: "{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties"
+          - configMapRef:
+              name: '{{ ansible_operator_meta.name }}-proxy-env'
+              optional: true
         ports:
         - containerPort: {{ default_http_port }}
           protocol: TCP

--- a/roles/model/defaults/main.yml
+++ b/roles/model/defaults/main.yml
@@ -150,6 +150,18 @@ bundle_cacert_secret: ''
 
 
 # ========================================
+# Proxy environment variables for model containers.
+# Defaults inherit from the operator pod environment (e.g. set by the OCP cluster
+# proxy object). Set these fields in the CR spec to override the inherited values
+# per instance.
+# ----------------------------------------
+http_proxy: "{{ lookup('env', 'http_proxy') or lookup('env', 'HTTP_PROXY') or '' }}"
+https_proxy: "{{ lookup('env', 'https_proxy') or lookup('env', 'HTTPS_PROXY') or '' }}"
+no_proxy: "{{ lookup('env', 'no_proxy') or lookup('env', 'NO_PROXY') or '' }}"
+# ========================================
+
+
+# ========================================
 # Django specific configuration
 # ----------------------------------------
 # Secret to lookup that provide the secret key

--- a/roles/model/templates/model.deployment.yaml.j2
+++ b/roles/model/templates/model.deployment.yaml.j2
@@ -49,6 +49,9 @@ spec:
   ] %}
         checksum-secret-{{ secret }}: "{{ lookup('ansible.builtin.vars', secret, default='')["resources"][0]["data"] | default('') | sha1 }}"
 {% endfor %}
+{% if http_proxy or https_proxy or no_proxy %}
+        checksum-proxy-env-configmap: "{{ lookup('template', '../common/templates/proxy-env.configmap.yaml.j2') | sha1 }}"
+{% endif %}
     spec:
       serviceAccountName: '{{ ansible_operator_meta.name }}'
 {% if image_pull_secrets | length > 0 %}
@@ -228,6 +231,9 @@ spec:
         envFrom:
           - configMapRef:
               name: "{{ ansible_operator_meta.name }}-{{ deployment_type }}-env-properties"
+          - configMapRef:
+              name: '{{ ansible_operator_meta.name }}-proxy-env'
+              optional: true
         ports:
         - containerPort: 8000
           protocol: TCP


### PR DESCRIPTION

Jira Issue: <https://issues.redhat.com/browse/AAP-71681>

## Description
Add http_proxy, https_proxy, and no_proxy CRD fields to the AnsibleAIConnect and AnsibleMCPConnect specs.

Add the proxy-aware OLM annotation to the CSV so that OLM injects cluster proxy configuration into the operator manager pod.

## Testing
Create the CR with proxy fields set:
```
  apiVersion: aiconnect.ansible.com/v1alpha1
  kind: AnsibleAIConnect
  metadata:
    name: ansibleaiconnect-sample
    namespace: ansible-ai-connect-scratch
  spec:
    ingress_type: Route
    http_proxy: 'http://proxy.example.com:3128'
    https_proxy: 'http://proxy.example.com:3128'
    no_proxy: 'localhost,127.0.0.1,.cluster.local,.svc'
```

### Scenarios tested
- no proxy variables passed
- only http_proxy, no_proxy
- only https_proxy, no_proxy
- all three variables

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This PR should be released in 2.4 (cherry-pick should be created)
- [ ] This PR should be released in 2.5 (cherry-pick should be created)
- [x] This PR should be released in 2.6 (cherry-pick should be created)
- [ ] This code change requires the following considerations before going to production:
