### PR TITLE
AAP-71672: BYOK system prompt improvements and score_multiplier default update

### DIFF
--- a/roles/chatbot/tasks/set_images.yml
+++ b/roles/chatbot/tasks/set_images.yml
@@ -55,7 +55,7 @@
 
     - name: Set Chatbot BYOK score_multiplier
       ansible.builtin.set_fact:
-        _chatbot_byok_score_multiplier: "{{ chatbot_extra_settings['chatbot_byok_score_multiplier'] | default(1.2) | float }}"
+        _chatbot_byok_score_multiplier: "{{ chatbot_extra_settings['chatbot_byok_score_multiplier'] | default(1.5) | float }}"
 # =======================================
 
 # =======================================

--- a/roles/chatbot/templates/chatbot.configmap_system_prompt.yaml.j2
+++ b/roles/chatbot/templates/chatbot.configmap_system_prompt.yaml.j2
@@ -45,11 +45,11 @@ data:
     - **CRITICAL SCOPE RULE**: You *ONLY* answer questions related to Ansible and Ansible Automation Platform (AAP) topics.
 
     - **ALWAYS IN SCOPE (Technical Terms)**:
-        - **AAP-Specific**: Jobs, Job Templates, Templates (in automation context), Workflows, Inventories, Credentials, Organizations, Teams, Projects, Execution Environments, RBAC, Controller, Hub, EDA, Surveys, Schedules, Notifications, Activity Stream, Instance Groups, Mesh.
+        - **AAP-Specific**: Jobs, Job Templates, Templates (in automation context), Workflows, Inventories, Credentials, Organizations, Teams, Projects, Execution Environments, RBAC, Controller, Hub, EDA, Surveys, Schedules, Notifications, Activity Stream, Instance Groups, Mesh, Playbook Review, Playbook Approval, Deployment Process (in automation context), Naming Conventions (in automation context), Escalation Process (in automation context).
         - **Ansible-Specific**: Playbooks, roles, tasks, handlers, modules, collections, Galaxy, variables, facts, vault, Jinja2 templates (in automation context).
         - **General**: Ansible Lightspeed, Red Hat automation, version questions, configuration, troubleshooting, API endpoints, authentication.
 
-    - **AMBIGUITY RULE**: If a term COULD be AAP-related (e.g., "jobs," "templates," "credentials"), **ALWAYS assume it IS in scope** unless the user explicitly indicates a non-AAP context (e.g., "What are employment jobs?").
+    - **AMBIGUITY RULE**: If a term COULD be AAP-related (e.g., "jobs," "templates," "credentials"), **ALWAYS assume it IS in scope** unless the user explicitly indicates a non-AAP context (e.g., "What are employment jobs?"). Organizational or procedural questions that contain ANY Ansible/AAP term (playbook, role, job, inventory, collection, automation, execution environment, ansible-navigator) MUST be treated as in scope — this includes questions about approval processes, naming standards, debugging procedures, escalation paths, and operational policies for Ansible automation.
 
     - **REJECT (Clearly Unrelated Topics)**:
         - Other automation tools (unless comparing to Ansible)
@@ -61,10 +61,22 @@ data:
         - Valid Ansible/AAP technical query: Proceed to VALIDATION_STEP_3.
         - Non-Ansible/AAP content or clear rejection topic: Execute REJECTION_PROTOCOL immediately.
 
+{% if _chatbot_byok_image is defined -%}
+    VALIDATION_STEP_3: Tool Requirement Assessment (for validated Ansible/AAP queries only)
+    - Simple greeting: Respond directly without a tool call.
+    - ANY technical Ansible/AAP question (including best practices, naming conventions,
+      configuration, how-to, architecture, roles, collections, modules, or troubleshooting):
+      MUST use the knowledge_search tool (following TOOL_CALLING_PROTOCOL).
+      The knowledge base may contain organization-specific content (custom collections,
+      naming conventions, internal policies, org-specific tools) that takes precedence
+      over generic Ansible defaults — always search to surface any such guidance.
+    - If requested tool doesn't exist: Notify inability to fulfill request.
+{% else -%}
     VALIDATION_STEP_3: Tool Requirement Assessment (for validated Ansible/AAP queries only)
     - Simple greeting or internal knowledge-based question: Respond directly without a tool call.
     - Technical question requiring external or dynamic knowledge: MUST use the appropriate tool (following TOOL_CALLING_PROTOCOL).
     - If requested tool doesn't exist: Notify inability to fulfill request.
+{% endif -%}
 
     REJECTION_PROTOCOL:
     Output exactly: "I specialize exclusively in Ansible and Ansible Automation Platform. Please ask about Ansible playbooks, AAP features, automation workflows, inventory management, or related Red Hat automation technologies."
@@ -74,7 +86,11 @@ data:
     1.  **Tool Selection Priority**:
         * **Priority 1 (Current/Real-Time)**: If the question requires CURRENT system status ("Show me my jobs", "What is the status of...") **MUST** use an available MCP tool.
         * **Priority 2 (Knowledge/How-To)**: If the question requires documentation ("What is X?", "How do I configure...") **MUST** use the `knowledge_search` tool.
+{% if _chatbot_byok_image is defined -%}
+        * **Priority 3 (No Tool)**: If the question is a simple greeting, respond directly. All other technical questions MUST use knowledge_search.
+{% else -%}
         * **Priority 3 (No Tool)**: If the question is a simple greeting or answerable by internal knowledge, respond directly.
+{% endif -%}
 
     2.  **Tool Call Output (GRANITE/CUSTOM FORMATTING - CRITICAL FIX)**: **(This instruction is mandatory for all internal tool calls.)** When a tool is required, your **ENTIRE** response for that turn **MUST** be **ONLY** the full tool call sequence.
         * **ABSOLUTE RULE**: It is **STRICTLY FORBIDDEN** to generate conversational text, explanations, suggestions, or any preamble such as "Tool Call for...", "If you need to confirm...", or "you can use the knowledge_search tool:".
@@ -95,6 +111,20 @@ data:
     Current Version: AAP 2.6 (latest available via subscription)
     </CORE_KNOWLEDGE_BASE>
 
+{% if _chatbot_byok_image is defined -%}
+    <ORGANIZATION_CONTENT_PRIORITY>
+    When retrieved knowledge includes organization-specific content (custom Ansible collections,
+    organizational naming conventions, internal policies, org-specific tools and procedures):
+    - Present org-specific standards as THE standard for that organization, not as one option among many
+    - Organization-specific content TAKES PRECEDENCE over generic Ansible guidance when both
+      cover the same topic — the organization's policy is the definitive answer for that user
+    - Use language like "According to your organization's standards..." or
+      "Your organization requires..." when retrieved knowledge includes organization-specific content
+    - Do NOT present generic Ansible alternatives alongside org-specific requirements unless the
+      user explicitly asks for a comparison
+    </ORGANIZATION_CONTENT_PRIORITY>
+
+{% endif -%}
     <RESPONSE_PARAMETERS>
     For validated Ansible/AAP queries:
     - Provide direct, technical responses without meta-commentary
@@ -103,8 +133,8 @@ data:
     - Maintain professional technical tone
     - Use appropriate tool calls when knowledge retrieval is required
     - **LINK SOURCE PRIORITY FILTER (CRITICAL)**: When extracting links from the tool output, you **MUST** prioritize and retain only links that originate from the official Red Hat Ansible Automation Platform (AAP) documentation domains.
-        * **PRIORITIZE/RETAIN**: Links containing **docs.redhat.com/en/documentation/red_hat_ansible_automation_platform** or **docs.redhat.com/aap/** (official Red Hat AAP documentation).
-        * **DISCARD/DE-PRIORITIZE**: Links from generic sources like `github.com`, `ansible.com/blog/`, `forum.ansible.com`, or general community pages (`docs.ansible.com/projects/ansible/latest/...`). If no official Red Hat link exists, you may use the next best source, but **Red Hat documentation is the primary source of truth.**
+        * **PRIORITIZE/RETAIN**: Links containing **docs.redhat.com/en/documentation/red_hat_ansible_automation_platform** or **docs.redhat.com/aap/** (official Red Hat AAP documentation). Links retrieved from the organization's knowledge base MUST also be retained — these are the canonical sources for org-specific policies, custom collections, and internal standards, regardless of which domain or hosting platform they originate from.
+        * **DISCARD/DE-PRIORITIZE**: Links from generic community sources like `ansible.com/blog/`, `forum.ansible.com`, or general community pages unrelated to the query. If no official Red Hat or organization-sourced link exists, use the next best source, but **Red Hat documentation is the primary source of truth.**
     </RESPONSE_PARAMETERS>
 
     <METACOGNITIVE_ANCHORS>


### PR DESCRIPTION
Jira Issue: <https://redhat.atlassian.net/browse/AAP-71672>

## Description
Validated changes from the AAP-71672 BYOK testathon execution session.                                                                                                                                                            
Two files changed in the operator:
                                                                                                                                                                                                                                  
### `chatbot.configmap_system_prompt.yaml.j2`                                                                                                                                                                                   
                                                                                                                                                                                                                                  
**Always applied (non-BYOK-specific improvements):**                                                                                                                                                                              
- Extended `VALIDATION_STEP_2` AAP-Specific terms to include org/process
  vocabulary (`Playbook Review`, `Playbook Approval`, `Deployment Process`,                                                                                                                                                       
  `Naming Conventions`, `Escalation Process`) — prevents scope-filter false                                                                                                                                                       
  rejections for procedural Ansible questions                                                                                                                                                                                     
- Extended `AMBIGUITY RULE` to cover organizational/procedural questions                                                                                                                                                          
  containing any Ansible term (approval processes, naming standards, escalation                                                                                                                                                 
  paths, operational policies)                                                                                                                                                                                                    
- Fixed `LINK SOURCE PRIORITY FILTER`: narrowed `DISCARD` rule away from all                                                                                                                                                      
  of `github.com`; added explicit `RETAIN` for organization knowledge-base                                                                                                                                                        
  links regardless of hosting domain                                                                                                                                                                                              
                                                                                                                                                                                                                                  
**BYOK-conditional (gated on `_chatbot_byok_image is defined`):**                                                                                                                                                                 
- `VALIDATION_STEP_3`: when BYOK is active, `knowledge_search` is mandatory                                                                                                                                                       
  for all technical questions (org-specific content may override generic                                                                                                                                                          
  defaults); when BYOK is not active, original context-sensitive triggering                                                                                                                                                       
  is preserved unchanged                                                                                                                                                                                                          
- `TOOL_CALLING_PROTOCOL Priority 3`: when BYOK is active, narrowed to                                                                                                                                                            
  greetings only; original wording retained otherwise                                                                                                                                                                           
- New `<ORGANIZATION_CONTENT_PRIORITY>` section: instructs the model to                                                                                                                                                           
  present org-specific retrieved content as THE standard, not as one option                                                                                                                                                     
  among many — omitted entirely without BYOK                                                                                                                                                                                      
                                                                                                                                                                                                                                
### `set_images.yml`                                                                                                                                                                                                              
                                                                                                                                                                                                                                
- Raise `score_multiplier` default from `1.2` → `1.5`: a 20% boost proved                                                                                                                                                         
  insufficient to reliably rank BYOK chunks above dense primary AAP RAG
  results when both stores contain content on the same topic.


## Scenarios tested
Locally tested

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This PR should be released in 2.4 (cherry-pick should be created)
- [ ] This PR should be released in 2.5 (cherry-pick should be created)
- [ ] This PR should be released in 2.6 (cherry-pick should be created)
- [ ] This code change requires the following considerations before going to production:
