### PR TITLE
Fix IMG variable shadowing operator.mk definition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ OPERATOR_SDK_VERSION ?= v1.40.0
 CONTAINER_TOOL ?= podman
 
 # Image URL to use all building/pushing image targets
-# IMG ?= $(IMAGE_TAG_BASE):$(VERSION)  # Set in operator.mk
+IMG ?= $(IMAGE_TAG_BASE):$(VERSION)
 
 .PHONY: all
 all: docker-build

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ OPERATOR_SDK_VERSION ?= v1.40.0
 CONTAINER_TOOL ?= podman
 
 # Image URL to use all building/pushing image targets
-IMG ?= $(IMAGE_TAG_BASE):$(VERSION)
+# IMG ?= $(IMAGE_TAG_BASE):$(VERSION)  # Set in operator.mk
 
 .PHONY: all
 all: docker-build

--- a/makefiles/operator.mk
+++ b/makefiles/operator.mk
@@ -6,7 +6,7 @@
 
 VERSION ?= $(shell git describe --tags 2>/dev/null || echo 0.1.0)
 IMAGE_TAG_BASE ?= quay.io/ansible/ansible-ai-connect
-IMG ?= $(IMAGE_TAG_BASE)-operator:$(VERSION)
+IMG = $(IMAGE_TAG_BASE)-operator:$(VERSION)
 NAMESPACE ?= ansible-ai-connect
 DEPLOYMENT_NAME ?= ansible-ai-connect-operator-controller-manager
 


### PR DESCRIPTION
## Summary

The operator-sdk generated Makefile defines `IMG ?= $(IMAGE_TAG_BASE):$(VERSION)`,
which resolves to `quay.io/ansible/ansible-ai-connect:<version>` — missing the
`-operator` suffix. Since `operator.mk` is `-include`d after the Makefile, its
`?=` assignment for `IMG` is ignored (the variable is already set).

Change to unconditional assignment (`=`) in `operator.mk` so its definition
takes precedence over the Makefile default. Command-line overrides
(`make bundle IMG=custom:tag`) still work since Make gives CLI variables
highest precedence.

Without this fix, `make bundle` writes the wrong image into
`config/manager/kustomization.yaml`, which the downstream downstreamify
script cannot match.

**Before (wrong):**
```
IMG = quay.io/ansible/ansible-ai-connect:0.6.508
```

**After (correct):**
```
IMG = quay.io/ansible/ansible-ai-connect-operator:0.6.508
```

Related: https://github.com/ansible-automation-platform/ansible-automation-platform-operator-bundle-container/pull/11736

## Test plan

- [ ] Run `make -p | grep '^IMG '` — verify it resolves to `$(IMAGE_TAG_BASE)-operator:$(VERSION)`
- [ ] Run `make bundle` — verify `config/manager/kustomization.yaml` retains `ansible-ai-connect-operator`
- [ ] Verify `make bundle IMG=custom:tag` still honors the override