### PR TITLE
Makefile: Fix IMG variable

### DIFF
--- a/makefiles/operator.mk
+++ b/makefiles/operator.mk
@@ -5,8 +5,7 @@
 #@ Operator Variables
 
 VERSION ?= $(shell git describe --tags 2>/dev/null || echo 0.1.0)
-IMAGE_TAG_BASE ?= quay.io/ansible/ansible-ai-connect
-IMG ?= $(IMAGE_TAG_BASE)-operator:$(VERSION)
+IMAGE_TAG_BASE ?= quay.io/ansible/ansible-ai-connect-operator
 NAMESPACE ?= ansible-ai-connect
 DEPLOYMENT_NAME ?= ansible-ai-connect-operator-controller-manager
 


### PR DESCRIPTION
## Description
The IMG variable should be define in the main Makefile but is missing the -operator suffix
The duplicated entry in the operator.mk can be removed