### PR TITLE
Add OPENAI_BASE_URL env var to chatbot deployment

### DIFF
--- a/roles/chatbot/templates/chatbot.deployment.yaml.j2
+++ b/roles/chatbot/templates/chatbot.deployment.yaml.j2
@@ -153,6 +153,8 @@ spec:
             value: {{ chatbot_model }}
           - name: INFERENCE_MODEL_FILTER
             value: {{ chatbot_model }}
+          - name: OPENAI_BASE_URL
+            value: {{ chatbot_url }}
         ports:
 {% if is_openshift %}
           - containerPort: 8443


### PR DESCRIPTION
## Summary

The chatbot container needs the `OPENAI_BASE_URL` environment variable set to the
configured provider URL (`{{ chatbot_url }}`) so that custom OpenAI-compatible endpoints
are used correctly. Without this variable, the chatbot ignores the custom URL and falls
back to the default OpenAI endpoint.

## Changes

- Added `OPENAI_BASE_URL` env var to the chatbot container in
  `roles/chatbot/templates/chatbot.deployment.yaml.j2`, set to the same value as
  `PROVIDER_URL`.

Fixes #744

Made with [Cursor](https://cursor.com)