### PR TITLE
Set status.URL when ingress_type is 'none'

### DIFF
--- a/roles/model/tasks/update_status.yml
+++ b/roles/model/tasks/update_status.yml
@@ -78,6 +78,17 @@
           URL: "https://{{ route_url['resources'][0]['status']['ingress'][0]['host'] }}"
   when: ingress_type | lower == 'route'
 
+- block:
+    - name: Update URL status for ingress type none
+      operator_sdk.util.k8s_status:
+        api_version: '{{ api_version }}'
+        kind: "{{ kind }}"
+        name: "{{ ansible_operator_meta.name }}"
+        namespace: "{{ ansible_operator_meta.namespace }}"
+        status:
+          URL: "https://{{ hostname }}"
+  when: ingress_type | lower == 'none'
+
 # ============================================
 # Retrieve and update Chatbot status
 # --------------------------------------------


### PR DESCRIPTION
## Summary

When `ingress_type` is set to `none` (a valid CRD enum value, commonly used when
the service is behind an external load balancer), the operator did not populate
`status.URL` on the custom resource. This made it impossible for users or tooling
to discover the service URL by inspecting the CR status.

## Changes

- Added a new block in `roles/model/tasks/update_status.yml` that sets `status.URL`
  to `https://{{ hostname }}` when `ingress_type` is `none`, using the user-supplied
  `hostname` field from the CR spec.

Fixes #745

Made with [Cursor](https://cursor.com)