### PR TITLE
AAP-72978: Guard initContainer securityContext runAsUser behind not is_openshift

### DIFF
--- a/roles/chatbot/templates/chatbot.deployment.yaml.j2
+++ b/roles/chatbot/templates/chatbot.deployment.yaml.j2
@@ -98,8 +98,10 @@ spec:
 {% if _chatbot_byok_image is defined %}
       - name: init-byok-vector-db
         image: '{{ _chatbot_byok_image }}'
+{% if not is_openshift %}
         securityContext:
           runAsUser: 1001
+{% endif %}
         env:
           - name: BYOK_CONFIG_CHATBOT_DIR
             value: /.llama/data/byok/distributions/ansible-chatbot


### PR DESCRIPTION
Jira Issue: <https://redhat.atlassian.net/browse/AAP-72978>

## Description
On OpenShift, Security Context Constraints dynamically assign UIDs and disallow explicit runAsUser values. The fix wraps the securityContext added in 4fb1527 (required for AKS) behind a {% if not is_openshift %} guard so it only applies on non-OpenShift clusters.

### Scenarios tested
Locally tested.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This PR should be released in 2.4 (cherry-pick should be created)
- [ ] This PR should be released in 2.5 (cherry-pick should be created)
- [ ] This PR should be released in 2.6 (cherry-pick should be created)
- [ ] This code change requires the following considerations before going to production:
