### PR TITLE
AAP-73116: Fix Jinja2 -%} whitespace stripping in system prompt template

### DIFF
--- a/roles/chatbot/templates/chatbot.configmap_system_prompt.yaml.j2
+++ b/roles/chatbot/templates/chatbot.configmap_system_prompt.yaml.j2
@@ -61,7 +61,7 @@ data:
         - Valid Ansible/AAP technical query: Proceed to VALIDATION_STEP_3.
         - Non-Ansible/AAP content or clear rejection topic: Execute REJECTION_PROTOCOL immediately.
 
-{% if _chatbot_byok_image is defined -%}
+{% if _chatbot_byok_image is defined %}
     VALIDATION_STEP_3: Tool Requirement Assessment (for validated Ansible/AAP queries only)
     - Simple greeting: Respond directly without a tool call.
     - ANY technical Ansible/AAP question (including best practices, naming conventions,
@@ -71,12 +71,12 @@ data:
       naming conventions, internal policies, org-specific tools) that takes precedence
       over generic Ansible defaults — always search to surface any such guidance.
     - If requested tool doesn't exist: Notify inability to fulfill request.
-{% else -%}
+{% else %}
     VALIDATION_STEP_3: Tool Requirement Assessment (for validated Ansible/AAP queries only)
     - Simple greeting or internal knowledge-based question: Respond directly without a tool call.
     - Technical question requiring external or dynamic knowledge: MUST use the appropriate tool (following TOOL_CALLING_PROTOCOL).
     - If requested tool doesn't exist: Notify inability to fulfill request.
-{% endif -%}
+{% endif %}
 
     REJECTION_PROTOCOL:
     Output exactly: "I specialize exclusively in Ansible and Ansible Automation Platform. Please ask about Ansible playbooks, AAP features, automation workflows, inventory management, or related Red Hat automation technologies."
@@ -86,11 +86,11 @@ data:
     1.  **Tool Selection Priority**:
         * **Priority 1 (Current/Real-Time)**: If the question requires CURRENT system status ("Show me my jobs", "What is the status of...") **MUST** use an available MCP tool.
         * **Priority 2 (Knowledge/How-To)**: If the question requires documentation ("What is X?", "How do I configure...") **MUST** use the `knowledge_search` tool.
-{% if _chatbot_byok_image is defined -%}
+{% if _chatbot_byok_image is defined %}
         * **Priority 3 (No Tool)**: If the question is a simple greeting, respond directly. All other technical questions MUST use knowledge_search.
-{% else -%}
+{% else %}
         * **Priority 3 (No Tool)**: If the question is a simple greeting or answerable by internal knowledge, respond directly.
-{% endif -%}
+{% endif %}
 
     2.  **Tool Call Output (GRANITE/CUSTOM FORMATTING - CRITICAL FIX)**: **(This instruction is mandatory for all internal tool calls.)** When a tool is required, your **ENTIRE** response for that turn **MUST** be **ONLY** the full tool call sequence.
         * **ABSOLUTE RULE**: It is **STRICTLY FORBIDDEN** to generate conversational text, explanations, suggestions, or any preamble such as "Tool Call for...", "If you need to confirm...", or "you can use the knowledge_search tool:".
@@ -111,7 +111,7 @@ data:
     Current Version: AAP 2.6 (latest available via subscription)
     </CORE_KNOWLEDGE_BASE>
 
-{% if _chatbot_byok_image is defined -%}
+{% if _chatbot_byok_image is defined %}
     <ORGANIZATION_CONTENT_PRIORITY>
     When retrieved knowledge includes organization-specific content (custom Ansible collections,
     organizational naming conventions, internal policies, org-specific tools and procedures):
@@ -124,7 +124,7 @@ data:
       user explicitly asks for a comparison
     </ORGANIZATION_CONTENT_PRIORITY>
 
-{% endif -%}
+{% endif %}
     <RESPONSE_PARAMETERS>
     For validated Ansible/AAP queries:
     - Provide direct, technical responses without meta-commentary


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-73116>
<!-- This PR does not need a corresponding Jira item. -->

**Co-Authored with:** Claude-4.6

## Description
Commit 3f9e647 introduced BYOK-conditional blocks into the chatbot system
prompt ConfigMap template (`roles/chatbot/templates/chatbot.configmap_system_prompt.yaml.j2`).
The `{% if %}`, `{% else %}`, and `{% endif %}` tags in those blocks were written
with a `-` whitespace-stripping modifier: `-%}`.

Inside a YAML literal block scalar (`DEFAULT_SYSTEM_PROMPT: |-`), the `-` modifier
combined with Ansible's default `trim_blocks=True` strips the leading indentation
from the next line after the tag. For non-BYOK deployments (where
`_chatbot_byok_image` is undefined), this caused `VALIDATION_STEP_3:` to render
at column 0 instead of the expected 4-space indent, producing invalid YAML.

This caused the following failure when the operator applied the ConfigMap:

```
Failed to load resource definition: mapping values are not allowed here
  in "<unicode string>", line 69, column 59
```

The chatbot Deployment then timed out with `ProgressDeadlineExceeded`, preventing
the chatbot from starting on any non-BYOK OCP deployment.

Observed in: `AAP_2.8_Next` pipeline — `tier1-ocp-a.fresh-install.mcp-server`

**Fix:** Remove the `-` from all six `-%}` tags (`{% if -%}`, `{% else -%}`,
`{% endif -%}`) across the three conditional blocks in the template.
This preserves the correct indentation in the rendered YAML for both
BYOK and non-BYOK deployments.

Relates to: AAP-72821 (the BYOK system prompt backport that introduced this template)

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run the following validation script from the repo root:

```bash
python3 -c "
import jinja2, yaml

template_path = 'roles/chatbot/templates/chatbot.configmap_system_prompt.yaml.j2'

with open(template_path) as f:
    raw = f.read()

raw_stripped = raw.replace(
    '{{ lookup(\"template\", \"../common/templates/labels/common.yaml.j2\") | indent(width=4) | trim }}',
    'app: lightspeed'
)

env = jinja2.Environment(undefined=jinja2.Undefined, trim_blocks=True, lstrip_blocks=False)

for label, ctx in [('NON-BYOK', {}), ('BYOK', {'_chatbot_byok_image': 'my-byok-image:latest'})]:
    ctx.update({'ansible_operator_meta': {'name': 'test', 'namespace': 'test-ns'}, 'deployment_type': 'chatbot'})
    rendered = env.from_string(raw_stripped).render(**ctx)
    try:
        yaml.safe_load(rendered)
        print(f'[{label}] YAML is VALID')
    except yaml.YAMLError as e:
        print(f'[{label}] YAML is INVALID: {e}')
"
```

3. Confirm output is:
```
[NON-BYOK] YAML is VALID
[BYOK] YAML is VALID
```

### Scenarios tested
- Non-BYOK deployment: template renders valid YAML ✅
- BYOK deployment: template renders valid YAML ✅

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [ ] This code change is ready for production on its own
- [ ] This PR should be released in 2.4 (cherry-pick should be created)
- [ ] This PR should be released in 2.5 (cherry-pick should be created)
- [ ] This PR should be released in 2.6 (cherry-pick should be created)
- [x] This code change requires the following considerations before going to production:
  - A backport to `stable-2.7` is required