### PR TITLE
Updates on MCP telemetry review request

### DIFF
--- a/config/crd/bases/mcpconnect.ansible.com_ansiblemcpconnectrestores.yaml
+++ b/config/crd/bases/mcpconnect.ansible.com_ansiblemcpconnectrestores.yaml
@@ -57,6 +57,10 @@ spec:
                 description: Maintain recommended labels
                 type: boolean
                 default: true
+              spec_overrides:
+                description: Overrides for the AnsibleMCPConnect spec
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
           status:
             type: object
             properties:

--- a/config/manifests/bases/ansible-ai-connect-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ansible-ai-connect-operator.clusterserviceversion.yaml
@@ -772,6 +772,10 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - displayName: MCP Spec Overrides
+        path: spec_overrides
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       statusDescriptors:
       - description: Flag indicating restore completion
         displayName: Restore Complete

--- a/config/manifests/bases/ansible-ai-connect-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ansible-ai-connect-operator.clusterserviceversion.yaml
@@ -772,7 +772,8 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - displayName: MCP Spec Overrides
+      - description: Overrides for the AnsibleMCPConnect spec during restore
+        displayName: MCP Spec Overrides
         path: spec_overrides
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced

--- a/roles/mcpbackup/tasks/configmap.yml
+++ b/roles/mcpbackup/tasks/configmap.yml
@@ -11,7 +11,7 @@
 
 - block:
     - name: Set MCP ConfigMap backup data
-      set_fact:
+      ansible.builtin.set_fact:
         mcp_backup_vars:
           configmap_name: "{{ _mcp_configmaps['resources'][0]['metadata']['name'] }}"
           configmap_data: "{{ _mcp_configmaps['resources'][0]['data'] }}"

--- a/roles/mcpbackup/tasks/init.yml
+++ b/roles/mcpbackup/tasks/init.yml
@@ -9,11 +9,11 @@
     wait: true
 
 - name: Set default pvc name
-  set_fact:
+  ansible.builtin.set_fact:
     _default_backup_pvc: "{{ deployment_name }}-backup-claim"
 
 - name: Set PVC to use for backup
-  set_fact:
+  ansible.builtin.set_fact:
     backup_pvc: "{{ backup_pvc | default(_default_backup_pvc, true) }}"
 
 - name: Create PVC for backup
@@ -56,7 +56,7 @@
   register: this_mcp
 
 - name: Set backup directory name
-  set_fact:
+  ansible.builtin.set_fact:
     backup_dir: "/backups/mcp-openshift-backup-{{ lookup('pipe', 'date +%F-%T') }}"
 
 - name: Create backup directory

--- a/roles/mcpbackup/tasks/main.yml
+++ b/roles/mcpbackup/tasks/main.yml
@@ -8,11 +8,11 @@
   register: this_backup
 
 - block:
-    - include_tasks: init.yml
-    - include_tasks: secrets.yml
-    - include_tasks: configmap.yml
-    - include_tasks: cleanup.yml
-    - include_tasks: update_status.yml
+    - ansible.builtin.include_tasks: init.yml
+    - ansible.builtin.include_tasks: secrets.yml
+    - ansible.builtin.include_tasks: configmap.yml
+    - ansible.builtin.include_tasks: cleanup.yml
+    - ansible.builtin.include_tasks: update_status.yml
 
   when:
     - this_backup['resources'][0]['status']['backupDirectory'] is not defined

--- a/roles/mcpbackup/tasks/secrets.yml
+++ b/roles/mcpbackup/tasks/secrets.yml
@@ -10,19 +10,19 @@
 
 - block:
     - name: Set MCP telemetry secret data
-      set_fact:
+      ansible.builtin.set_fact:
         _data: "{{ _mcp_telemetry_secret['resources'][0]['data'] }}"
         _type: "{{ _mcp_telemetry_secret['resources'][0]['type'] }}"
       no_log: "{{ no_log }}"
 
     - name: Add MCP telemetry HMAC secret to dictionary
-      set_fact:
+      ansible.builtin.set_fact:
         secret_dict: "{{ secret_dict | default({}) | combine({'mcpTelemetryHmacSecret': {'name': _mcp_telemetry_secret['resources'][0]['metadata']['name'], 'data': _data, 'type': _type}}) }}"
       no_log: "{{ no_log }}"
   when: _mcp_telemetry_secret['resources'] | default([]) | length
 
 - name: Nest secrets under a single variable
-  set_fact:
+  ansible.builtin.set_fact:
     secrets: {"secrets": '{{ secret_dict | default({}) }}'}
   no_log: "{{ no_log }}"
 

--- a/roles/mcprestore/defaults/main.yml
+++ b/roles/mcprestore/defaults/main.yml
@@ -8,3 +8,4 @@ backup_pvc_namespace: '{{ ansible_operator_meta.namespace }}'
 
 no_log: true
 set_self_labels: true
+spec_overrides: {}

--- a/roles/mcprestore/tasks/configmap.yml
+++ b/roles/mcprestore/tasks/configmap.yml
@@ -9,7 +9,7 @@
 
 - block:
     - name: Create temporary MCP backup vars file
-      tempfile:
+      ansible.builtin.tempfile:
         state: file
         suffix: .yml
       register: _tmp_mcp_vars
@@ -24,7 +24,7 @@
       no_log: "{{ no_log }}"
 
     - name: Include MCP backup vars
-      include_vars: "{{ _tmp_mcp_vars.path }}"
+      ansible.builtin.include_vars: "{{ _tmp_mcp_vars.path }}"
       no_log: "{{ no_log }}"
 
     - name: Pre-create MCP ConfigMap from backup
@@ -44,7 +44,7 @@
 
   always:
     - name: Remove temporary MCP backup vars file
-      file:
+      ansible.builtin.file:
         path: "{{ _tmp_mcp_vars.path }}"
         state: absent
       when: _tmp_mcp_vars is defined

--- a/roles/mcprestore/tasks/create_cr.yml
+++ b/roles/mcprestore/tasks/create_cr.yml
@@ -1,0 +1,50 @@
+---
+- block:
+    - name: Determine public_base_url for restored deployment
+      ansible.builtin.set_fact:
+        public_base_url: >-
+          {{
+            spec_overrides.public_base_url | default(
+              mcp_backup_vars.configmap_data.BASE_URL | default('')
+            )
+          }}
+      no_log: "{{ no_log }}"
+
+    - name: Fail if public_base_url is not available
+      ansible.builtin.fail:
+        msg: |
+          Cannot create AnsibleMCPConnect CR: public_base_url is required but not found.
+          Please provide it in spec_overrides.public_base_url or ensure backup data contains BASE_URL.
+      when: public_base_url == ''
+
+    - name: Build base AnsibleMCPConnect spec
+      ansible.builtin.set_fact:
+        base_mcp_spec:
+          public_base_url: "{{ public_base_url }}"
+          no_log: "{{ no_log }}"
+          set_self_labels: "{{ set_self_labels }}"
+      no_log: "{{ no_log }}"
+
+    - name: Merge spec_overrides into base spec
+      ansible.builtin.set_fact:
+        final_mcp_spec: "{{ base_mcp_spec | combine(spec_overrides, recursive=True) }}"
+      no_log: "{{ no_log }}"
+
+    - name: Create AnsibleMCPConnect CR from restore
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: mcpconnect.ansible.com/v1alpha1
+          kind: AnsibleMCPConnect
+          metadata:
+            name: "{{ deployment_name }}"
+            namespace: "{{ ansible_operator_meta.namespace }}"
+            labels:
+              app.kubernetes.io/name: "{{ deployment_name }}"
+              app.kubernetes.io/part-of: ansible-mcp-connect
+              app.kubernetes.io/managed-by: ansible-mcp-connect-operator
+              app.kubernetes.io/created-by: mcprestore
+          spec: "{{ final_mcp_spec }}"
+      no_log: "{{ no_log }}"
+
+  when: mcp_backup_vars is defined

--- a/roles/mcprestore/tasks/init.yml
+++ b/roles/mcprestore/tasks/init.yml
@@ -9,7 +9,7 @@
   when: backup_name | default('') | length
 
 - name: Set backup PVC and directory from backup CR
-  set_fact:
+  ansible.builtin.set_fact:
     backup_pvc: "{{ _backup_cr['resources'][0]['status']['backupClaim'] }}"
     backup_dir: "{{ _backup_cr['resources'][0]['status']['backupDirectory'] }}"
   when:

--- a/roles/mcprestore/tasks/main.yml
+++ b/roles/mcprestore/tasks/main.yml
@@ -10,7 +10,7 @@
 - block:
     - name: Combine spec_overrides with spec
       ansible.builtin.set_fact:
-        spec: "{{ spec | default({}) | combine(spec_overrides) }}"
+        spec: "{{ spec | default({}) | combine(spec_overrides, recursive=True) }}"
       no_log: "{{ no_log }}"
 
     - ansible.builtin.include_tasks: init.yml

--- a/roles/mcprestore/tasks/main.yml
+++ b/roles/mcprestore/tasks/main.yml
@@ -8,11 +8,16 @@
   register: this_restore
 
 - block:
-    - include_tasks: init.yml
-    - include_tasks: secrets.yml
-    - include_tasks: configmap.yml
-    - include_tasks: cleanup.yml
-    - include_tasks: update_status.yml
+    - name: Combine spec_overrides with spec
+      ansible.builtin.set_fact:
+        spec: "{{ spec | default({}) | combine(spec_overrides) }}"
+      no_log: "{{ no_log }}"
+
+    - ansible.builtin.include_tasks: init.yml
+    - ansible.builtin.include_tasks: secrets.yml
+    - ansible.builtin.include_tasks: configmap.yml
+    - ansible.builtin.include_tasks: cleanup.yml
+    - ansible.builtin.include_tasks: update_status.yml
 
   when:
     - this_restore['resources'][0]['status']['restoreComplete'] is not defined

--- a/roles/mcprestore/tasks/main.yml
+++ b/roles/mcprestore/tasks/main.yml
@@ -16,6 +16,7 @@
     - ansible.builtin.include_tasks: init.yml
     - ansible.builtin.include_tasks: secrets.yml
     - ansible.builtin.include_tasks: configmap.yml
+    - ansible.builtin.include_tasks: create_cr.yml
     - ansible.builtin.include_tasks: cleanup.yml
     - ansible.builtin.include_tasks: update_status.yml
 

--- a/roles/mcprestore/tasks/secrets.yml
+++ b/roles/mcprestore/tasks/secrets.yml
@@ -9,7 +9,7 @@
 
 - block:
     - name: Create temporary secrets file
-      tempfile:
+      ansible.builtin.tempfile:
         state: file
         suffix: .yml
       register: _tmp_secrets
@@ -24,7 +24,7 @@
       no_log: "{{ no_log }}"
 
     - name: Include secret vars from backup
-      include_vars: "{{ _tmp_secrets.path }}"
+      ansible.builtin.include_vars: "{{ _tmp_secrets.path }}"
       no_log: "{{ no_log }}"
 
     - name: Restore MCP telemetry HMAC secret
@@ -41,9 +41,21 @@
       no_log: "{{ no_log }}"
       when: secrets.mcpTelemetryHmacSecret is defined
 
+    - name: Remove ownerReference on restored secrets
+      kubernetes.core.k8s:
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: '{{ secrets.mcpTelemetryHmacSecret.name }}'
+            namespace: '{{ ansible_operator_meta.namespace }}'
+            ownerReferences: null
+      no_log: "{{ no_log }}"
+      when: secrets.mcpTelemetryHmacSecret is defined
+
   always:
     - name: Remove temporary secrets file
-      file:
+      ansible.builtin.file:
         path: "{{ _tmp_secrets.path }}"
         state: absent
       when: _tmp_secrets is defined


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://redhat.atlassian.net/browse/AAP-70090
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
- Remove `ownerReferences` from restored secrets to prevent garbage collection
- Add `spec_overrides` support to MCP restore CRD, defaults, and CSV
- Add `spec_overrides` merge task to MCP restore flow
- Standardize module names to FQCN in `mcpbackup` and `mcprestore` roles

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run the molecule tests


## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This PR should be released in 2.4 (cherry-pick should be created)
- [ ] This PR should be released in 2.5 (cherry-pick should be created)
- [X] This PR should be released in 2.6 (cherry-pick should be created)
- [ ] This code change requires the following considerations before going to production:
