### PR TITLE
refactor: remove proxy env var CRD fields and CSV specDescriptors

### DIFF
--- a/config/crd/bases/aiconnect.ansible.com_ansibleaiconnects.yaml
+++ b/config/crd/bases/aiconnect.ansible.com_ansibleaiconnects.yaml
@@ -1027,15 +1027,6 @@ spec:
               bundle_cacert_secret:
                 description: Secret where the trusted Certificate Authority Bundle is stored
                 type: string
-              http_proxy:
-                description: HTTP proxy URL to configure on AnsibleAIConnect containers
-                type: string
-              https_proxy:
-                description: HTTPS proxy URL to configure on AnsibleAIConnect containers
-                type: string
-              no_proxy:
-                description: Comma-separated list of hosts that bypass the proxy on AnsibleAIConnect containers
-                type: string
               db_fields_encryption_secret:
                 description: Secret where the DB fields encryption key can be found. If not specified, one will be generated.
                 type: string

--- a/config/crd/bases/mcpconnect.ansible.com_ansiblemcpconnects.yaml
+++ b/config/crd/bases/mcpconnect.ansible.com_ansiblemcpconnects.yaml
@@ -477,15 +477,6 @@ spec:
               bundle_cacert_secret:
                 description: Secret where the trusted Certificate Authority Bundle is stored
                 type: string
-              http_proxy:
-                description: HTTP proxy URL to configure on AnsibleMCPConnect containers
-                type: string
-              https_proxy:
-                description: HTTPS proxy URL to configure on AnsibleMCPConnect containers
-                type: string
-              no_proxy:
-                description: Comma-separated list of hosts that bypass the proxy on AnsibleMCPConnect containers
-                type: string
               set_self_labels:
                 description: Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
                 type: boolean

--- a/config/manifests/bases/ansible-ai-connect-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ansible-ai-connect-operator.clusterserviceversion.yaml
@@ -349,24 +349,6 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
-      - description: HTTP proxy URL to configure on AI Connect containers
-        displayName: HTTP Proxy
-        path: http_proxy
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: HTTPS proxy URL to configure on AI Connect containers
-        displayName: HTTPS Proxy
-        path: https_proxy
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Comma-separated list of hosts that bypass the proxy on AI Connect containers
-        displayName: No Proxy
-        path: no_proxy
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Name of the k8s secret the DB fields encryption key is stored
           in.
         displayName: DB Fields Encryption Key
@@ -645,24 +627,6 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
-      - description: HTTP proxy URL to configure on MCP Connect containers
-        displayName: HTTP Proxy
-        path: http_proxy
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: HTTPS proxy URL to configure on MCP Connect containers
-        displayName: HTTPS Proxy
-        path: https_proxy
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Comma-separated list of hosts that bypass the proxy on MCP Connect containers
-        displayName: No Proxy
-        path: no_proxy
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:text
       - displayName: AAP Gateway URL
         path: aap_gateway_url
         x-descriptors:

--- a/roles/chatbot/defaults/main.yml
+++ b/roles/chatbot/defaults/main.yml
@@ -62,9 +62,7 @@ _chatbot_api:
 
 # ========================================
 # Proxy environment variables for chatbot containers.
-# Defaults inherit from the operator pod environment (e.g. set by the OCP cluster
-# proxy object). Set these fields in the CR spec to override the inherited values
-# per instance.
+# Values are inherited from the operator pod environment.
 # ----------------------------------------
 http_proxy: "{{ lookup('env', 'http_proxy') or lookup('env', 'HTTP_PROXY') or '' }}"
 https_proxy: "{{ lookup('env', 'https_proxy') or lookup('env', 'HTTPS_PROXY') or '' }}"

--- a/roles/mcpserver/defaults/main.yml
+++ b/roles/mcpserver/defaults/main.yml
@@ -152,9 +152,7 @@ bundle_cacert_secret: ''
 
 # ========================================
 # Proxy environment variables for mcpserver containers.
-# Defaults inherit from the operator pod environment (e.g. set by the OCP cluster
-# proxy object). Set these fields in the CR spec to override the inherited values
-# per instance.
+# Values are inherited from the operator pod environment.
 # ----------------------------------------
 http_proxy: "{{ lookup('env', 'http_proxy') or lookup('env', 'HTTP_PROXY') or '' }}"
 https_proxy: "{{ lookup('env', 'https_proxy') or lookup('env', 'HTTPS_PROXY') or '' }}"

--- a/roles/model/defaults/main.yml
+++ b/roles/model/defaults/main.yml
@@ -151,9 +151,7 @@ bundle_cacert_secret: ''
 
 # ========================================
 # Proxy environment variables for model containers.
-# Defaults inherit from the operator pod environment (e.g. set by the OCP cluster
-# proxy object). Set these fields in the CR spec to override the inherited values
-# per instance.
+# Values are inherited from the operator pod environment.
 # ----------------------------------------
 http_proxy: "{{ lookup('env', 'http_proxy') or lookup('env', 'HTTP_PROXY') or '' }}"
 https_proxy: "{{ lookup('env', 'https_proxy') or lookup('env', 'HTTPS_PROXY') or '' }}"


### PR DESCRIPTION
## Summary

- Removes `http_proxy`, `https_proxy`, and `no_proxy` from both the
  AnsibleAIConnect and AnsibleMCPConnect CRD specs and CSV specDescriptors
- Proxy configuration is injected into the operator pod environment and
  propagated to containers via the existing ConfigMap mechanism

## Test plan

- [x] Verify operator reconciles cleanly with no failed tasks
- [x] Verify proxy environment variables are not exposed in CRD spec