### PR TITLE
ci: skip repo-sync workflow in downstream org

### DIFF
--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -21,6 +21,7 @@ env:
 jobs:
   sync:
     name: "Sync → ansible-lightspeed-operator-source"
+    if: github.repository_owner == 'ansible'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary

Adds an `if: github.repository_owner == 'ansible'` guard to the repo-sync workflow job so it is silently skipped when the workflow file is mirrored to the downstream `ansible-automation-platform` org.

Without this guard, every sync push to downstream `main` would re-trigger the workflow there — either failing (if the upstream/downstream repo names differ) or causing an infinite loop (if the names match).

## Test plan

- [ ] Verify the workflow still triggers normally on push to `main` in the upstream `ansible` org
- [ ] Confirm the job shows as "skipped" in the downstream org's Actions tab after the next sync

Made with [Cursor](https://cursor.com)