### PR TITLE
deprecate: mark postgres_keep_pvc_after_upgrade deprecated and remove implementation

### DIFF
--- a/config/crd/bases/aiconnect.ansible.com_ansibleaiconnects.yaml
+++ b/config/crd/bases/aiconnect.ansible.com_ansibleaiconnects.yaml
@@ -221,9 +221,8 @@ spec:
                       Default: "prefer"'
                     type: string
                   postgres_keep_pvc_after_upgrade:
-                    description: Specify whether or not to keep the old PVC after PostgreSQL upgrades
+                    description: "(Deprecated) Specify whether or not to keep the old PVC after PostgreSQL upgrades"
                     type: boolean
-                    default: true
                   storage_requirements:
                     description: Storage requirements for the PostgreSQL container
                     properties:

--- a/config/manifests/bases/ansible-ai-connect-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ansible-ai-connect-operator.clusterserviceversion.yaml
@@ -204,11 +204,6 @@ spec:
         path: database.priority_class
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - displayName: Should PostgreSQL data for managed databases be kept after upgrades?
-        path: database.postgres_keep_pvc_after_upgrade
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - displayName: Database Extra Arguments (Deprecated)
         path: database.postgres_extra_args
         x-descriptors:

--- a/docs/upgrade/upgrading.md
+++ b/docs/upgrade/upgrading.md
@@ -38,16 +38,3 @@ Then run this to apply it:
 ```
 kustomize build . | kubectl apply -f -
 ```
-
-#### PostgreSQL Upgrade Considerations
-
-If there is a PostgreSQL major version upgrade, after the data directory on the `PersistentVolumeClaim` is migrated to the new version, the old `PersistentVolumeClaim` is kept by default.
-
-This provides the ability to roll back if needed, but can take up extra storage space in your cluster unnecessarily. By default, the Postgres `PersistentVolumeClaim` from the previous version will remain unless you manually remove it, or have the `database.postgres_keep_pvc_after_upgrade` parameter set to `false`. You can configure it to be deleted automatically
-after a successful upgrade by setting the following variable on the `AnsibleAIConnect` specification.
-
-```yaml
-  spec:
-    database:
-        postgres_keep_pvc_after_upgrade: false
-```

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -51,7 +51,6 @@ _database:
   priority_class: ''
   postgres_extra_args: ''  # Deprecated
   postgres_extra_settings: []  # Define postgresql.conf configurations
-  postgres_keep_pvc_after_upgrade: true  # Specify whether or not to keep the old PVC after PostgreSQL upgrades
   postgres_data_volume_init: false
   postgres_init_container_commands: |
     chown 26:0 /var/lib/pgsql/data

--- a/roles/postgres/tasks/upgrade_postgres.yml
+++ b/roles/postgres/tasks/upgrade_postgres.yml
@@ -169,14 +169,4 @@
     namespace: "{{ ansible_operator_meta.namespace }}"
     state: absent
 
-- name: Remove old PersistentVolumeClaim
-  kubernetes.core.k8s:
-    kind: PersistentVolumeClaim
-    api_version: v1
-    namespace: "{{ ansible_operator_meta.namespace }}"
-    label_selectors:
-      - "app.kubernetes.io/instance={{ old_postgres_pod_name }}-{{ ansible_operator_meta.name }}"
-      - "app.kubernetes.io/managed-by={{ deployment_type }}-operator"
-    state: absent
-  when: not combined_database.postgres_keep_pvc_after_upgrade | bool
 # ==============================================


### PR DESCRIPTION
## Summary

Deprecates `postgres_keep_pvc_after_upgrade` in the CRD and removes the
implementation. The field has no effect going forward; old Postgres PVCs are
always preserved after upgrade, consistent with standard behavior across
platform operators.

- Mark field as `(Deprecated)` in CRD description
- Remove PVC deletion task from `upgrade_postgres.yml`
- Remove CSV specDescriptor entry
- Remove role default
- Remove upgrading.md usage example