### PR TITLE
AAP-76952: Auto-set CSRF_TRUSTED_ORIGINS from Route/Ingress host

### DIFF
--- a/molecule/default/tasks/10_0_csrf_trusted_origins_test.yml
+++ b/molecule/default/tasks/10_0_csrf_trusted_origins_test.yml
@@ -13,10 +13,18 @@
           - "'CSRF_TRUSTED_ORIGINS' in aiconnect_configmap.resources[0].data"
         fail_msg: ConfigMap does not contain CSRF_TRUSTED_ORIGINS
 
-    - name: Assert CSRF_TRUSTED_ORIGINS contains the expected origin
+    - name: Assert CSRF_TRUSTED_ORIGINS contains the Lightspeed origin
       ansible.builtin.assert:
         that:
-          - "aiconnect_configmap.resources[0].data.CSRF_TRUSTED_ORIGINS == 'https://test.example.com'"
+          - "'http://test.example.com' in aiconnect_configmap.resources[0].data.CSRF_TRUSTED_ORIGINS"
         fail_msg: >-
-          CSRF_TRUSTED_ORIGINS expected 'https://test.example.com',
+          CSRF_TRUSTED_ORIGINS does not contain 'http://test.example.com',
+          got '{{ aiconnect_configmap.resources[0].data.CSRF_TRUSTED_ORIGINS }}'
+
+    - name: Assert CSRF_TRUSTED_ORIGINS contains the gateway origin
+      ansible.builtin.assert:
+        that:
+          - "'https://my-aap-gateway.example.com' in aiconnect_configmap.resources[0].data.CSRF_TRUSTED_ORIGINS"
+        fail_msg: >-
+          CSRF_TRUSTED_ORIGINS does not contain 'https://my-aap-gateway.example.com',
           got '{{ aiconnect_configmap.resources[0].data.CSRF_TRUSTED_ORIGINS }}'

--- a/molecule/default/tasks/10_0_csrf_trusted_origins_test.yml
+++ b/molecule/default/tasks/10_0_csrf_trusted_origins_test.yml
@@ -16,7 +16,7 @@
     - name: Assert CSRF_TRUSTED_ORIGINS contains the Lightspeed origin
       ansible.builtin.assert:
         that:
-          - "'http://test.example.com' in aiconnect_configmap.resources[0].data.CSRF_TRUSTED_ORIGINS"
+          - "'http://test.example.com' in (aiconnect_configmap.resources[0].data.CSRF_TRUSTED_ORIGINS | split(','))"
         fail_msg: >-
           CSRF_TRUSTED_ORIGINS does not contain 'http://test.example.com',
           got '{{ aiconnect_configmap.resources[0].data.CSRF_TRUSTED_ORIGINS }}'
@@ -24,7 +24,7 @@
     - name: Assert CSRF_TRUSTED_ORIGINS contains the gateway origin
       ansible.builtin.assert:
         that:
-          - "'https://my-aap-gateway.example.com' in aiconnect_configmap.resources[0].data.CSRF_TRUSTED_ORIGINS"
+          - "'https://my-aap-gateway.example.com' in (aiconnect_configmap.resources[0].data.CSRF_TRUSTED_ORIGINS | split(','))"
         fail_msg: >-
           CSRF_TRUSTED_ORIGINS does not contain 'https://my-aap-gateway.example.com',
           got '{{ aiconnect_configmap.resources[0].data.CSRF_TRUSTED_ORIGINS }}'

--- a/molecule/default/tasks/10_0_csrf_trusted_origins_test.yml
+++ b/molecule/default/tasks/10_0_csrf_trusted_origins_test.yml
@@ -1,0 +1,22 @@
+---
+- block:
+    - name: Get ConfigMap details
+      kubernetes.core.k8s_info:
+        namespace: '{{ namespace }}'
+        kind: ConfigMap
+        name: ansibleaiconnect-sample-ansible-ai-connect-env-properties
+      register: aiconnect_configmap
+
+    - name: Assert CSRF_TRUSTED_ORIGINS is set in ConfigMap
+      ansible.builtin.assert:
+        that:
+          - "'CSRF_TRUSTED_ORIGINS' in aiconnect_configmap.resources[0].data"
+        fail_msg: ConfigMap does not contain CSRF_TRUSTED_ORIGINS
+
+    - name: Assert CSRF_TRUSTED_ORIGINS contains the expected origin
+      ansible.builtin.assert:
+        that:
+          - "aiconnect_configmap.resources[0].data.CSRF_TRUSTED_ORIGINS == 'https://test.example.com'"
+        fail_msg: >-
+          CSRF_TRUSTED_ORIGINS expected 'https://test.example.com',
+          got '{{ aiconnect_configmap.resources[0].data.CSRF_TRUSTED_ORIGINS }}'

--- a/molecule/default/templates/create_instance.yaml.j2
+++ b/molecule/default/templates/create_instance.yaml.j2
@@ -11,6 +11,7 @@ metadata:
 spec:
   no_log: false
   ingress_type: Ingress
+  hostname: test.example.com
   service_type: NodePort
   image_pull_secrets:
     - redhat-operators-pull-secret

--- a/molecule/default/templates/secrets/auth_config.secret.yaml.j2
+++ b/molecule/default/templates/secrets/auth_config.secret.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   name: auth-configuration-secret
   namespace: {{ namespace }}
 data:
-  auth_api_url: 'bXktYWFwLWFwaS11cmw='
+  auth_api_url: 'aHR0cHM6Ly9teS1hYXAtZ2F0ZXdheS5leGFtcGxlLmNvbQ=='
   auth_api_key: 'bXktYWFwLWtleQ=='
   auth_api_secret: 'bXktYWFwLXNlY3JldA=='
   auth_verify_ssl: 'ZmFsc2U='

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -26,6 +26,7 @@
             - tasks/7_0_instance_version_test.yml
             - tasks/8_0_admin_user_test.yml
             - tasks/9_0_azure_openai_url_append_test.yml
+            - tasks/10_0_csrf_trusted_origins_test.yml
           tags:
             - always
       rescue:

--- a/roles/model/tasks/main.yml
+++ b/roles/model/tasks/main.yml
@@ -45,6 +45,9 @@
     - ingress_type | lower == 'route'
     - route_tls_secret | length
 
+- name: Resolve CSRF trusted origins
+  ansible.builtin.include_tasks: resolve_csrf_origins.yml
+
 - name: Deploy Model API service
   ansible.builtin.include_tasks: deploy_model_api.yml
 

--- a/roles/model/tasks/resolve_csrf_origins.yml
+++ b/roles/model/tasks/resolve_csrf_origins.yml
@@ -1,0 +1,31 @@
+---
+- name: Look up existing Route host
+  kubernetes.core.k8s_info:
+    api_version: '{{ route_api_version }}'
+    kind: Route
+    namespace: '{{ ansible_operator_meta.namespace }}'
+    name: '{{ ansible_operator_meta.name }}'
+  register: _existing_route
+  when: ingress_type | lower == 'route'
+
+- name: Set CSRF trusted origins
+  ansible.builtin.set_fact:
+    _csrf_trusted_origins: >-
+      {%- set origins = [] -%}
+      {%- if ingress_type | lower == 'route' -%}
+        {%- if route_host | length -%}
+          {%- set _ = origins.append('https://' + route_host) -%}
+        {%- elif _existing_route.resources | default([]) | length > 0
+                and _existing_route.resources[0].status is defined
+                and _existing_route.resources[0].status.ingress is defined
+                and _existing_route.resources[0].status.ingress | length > 0 -%}
+          {%- set _ = origins.append('https://' + _existing_route.resources[0].status.ingress[0].host) -%}
+        {%- endif -%}
+      {%- elif ingress_type | lower == 'ingress' and hostname | length -%}
+        {%- if ingress_tls_secret | length -%}
+          {%- set _ = origins.append('https://' + hostname) -%}
+        {%- else -%}
+          {%- set _ = origins.append('https://' + hostname) -%}
+        {%- endif -%}
+      {%- endif -%}
+      {{ origins | join(',') }}

--- a/roles/model/tasks/resolve_csrf_origins.yml
+++ b/roles/model/tasks/resolve_csrf_origins.yml
@@ -48,4 +48,4 @@
           {%- endif -%}
         {%- endif -%}
       {%- endif -%}
-      {{ origins | join(',') }}
+      {{- origins | join(',') -}}

--- a/roles/model/tasks/resolve_csrf_origins.yml
+++ b/roles/model/tasks/resolve_csrf_origins.yml
@@ -22,10 +22,30 @@
           {%- set _ = origins.append('https://' + _existing_route.resources[0].status.ingress[0].host) -%}
         {%- endif -%}
       {%- elif ingress_type | lower == 'ingress' and hostname | length -%}
-        {%- if ingress_tls_secret | length -%}
-          {%- set _ = origins.append('https://' + hostname) -%}
-        {%- else -%}
-          {%- set _ = origins.append('https://' + hostname) -%}
+        {%- set scheme = 'https' if ingress_tls_secret | length else 'http' -%}
+        {%- set _ = origins.append(scheme + '://' + hostname) -%}
+      {%- endif -%}
+      {%- if auth_config is defined
+              and auth_config.resources | default([]) | length > 0
+              and auth_config.resources[0].data.auth_api_url is defined -%}
+        {%- set gateway_url = auth_config.resources[0].data.auth_api_url | b64decode -%}
+        {%- set gw_scheme = gateway_url | urlsplit('scheme') -%}
+        {%- set gw_netloc = gateway_url | urlsplit('netloc') -%}
+        {%- if gw_scheme and gw_netloc -%}
+          {%- set gw_origin = gw_scheme + '://' + gw_netloc -%}
+          {%- if gw_origin not in origins -%}
+            {%- set _ = origins.append(gw_origin) -%}
+          {%- endif -%}
+        {%- endif -%}
+      {%- endif -%}
+      {%- if _aap_gateway_url is defined and _aap_gateway_url | length -%}
+        {%- set gw2_scheme = _aap_gateway_url | urlsplit('scheme') -%}
+        {%- set gw2_netloc = _aap_gateway_url | urlsplit('netloc') -%}
+        {%- if gw2_scheme and gw2_netloc -%}
+          {%- set gw2_origin = gw2_scheme + '://' + gw2_netloc -%}
+          {%- if gw2_origin not in origins -%}
+            {%- set _ = origins.append(gw2_origin) -%}
+          {%- endif -%}
         {%- endif -%}
       {%- endif -%}
       {{ origins | join(',') }}

--- a/roles/model/templates/model.configmap.yaml.j2
+++ b/roles/model/templates/model.configmap.yaml.j2
@@ -36,7 +36,7 @@ data:
   PYTHONUNBUFFERED: "1"
 
 {% if _csrf_trusted_origins | default('') | length and not (extra_settings | default([]) | map(attribute='setting') | map('upper') | select('equalto', 'CSRF_TRUSTED_ORIGINS') | list | length) %}
-  CSRF_TRUSTED_ORIGINS: "{{ _csrf_trusted_origins }}"
+  CSRF_TRUSTED_ORIGINS: "{{ _csrf_trusted_origins | trim }}"
 {% endif %}
 
   # Custom user variables

--- a/roles/model/templates/model.configmap.yaml.j2
+++ b/roles/model/templates/model.configmap.yaml.j2
@@ -35,6 +35,10 @@ data:
 
   PYTHONUNBUFFERED: "1"
 
+{% if _csrf_trusted_origins | default('') | length and not (extra_settings | default([]) | map(attribute='setting') | map('upper') | select('equalto', 'CSRF_TRUSTED_ORIGINS') | list | length) %}
+  CSRF_TRUSTED_ORIGINS: "{{ _csrf_trusted_origins }}"
+{% endif %}
+
   # Custom user variables
 {% for item in extra_settings | default([]) %}
   {{ item.setting | upper }}: "{{ item.value }}"


### PR DESCRIPTION
## Summary
- Resolves the service's Route or Ingress hostname and automatically sets `CSRF_TRUSTED_ORIGINS` in the model ConfigMap
- Also includes the AAP gateway origin from `auth_api_url` (auth secret) and `_aap_gateway_url` (chatbot secret)
- Django will accept CSRF tokens from both the Lightspeed service origin and the gateway origin without manual `extra_settings` configuration
- Users can still override via `extra_settings` if needed — the auto-derived value is skipped when an explicit override is present

## Details
- New task `resolve_csrf_origins.yml` resolves CSRF trusted origins from three sources:
  1. **Lightspeed service origin** — from Route status, `route_host`, or Ingress `hostname`
  2. **Gateway origin (auth secret)** — extracted from `auth_api_url` in the auth-configuration-secret
  3. **Gateway origin (chatbot secret)** — extracted from `_aap_gateway_url` set by the chatbot role
- Origins are deduplicated before being joined into a comma-separated string
- For Ingress, the scheme (`http`/`https`) is derived from whether `ingress_tls_secret` is set
- For Routes with auto-generated hostnames, the value is resolved on the second reconciliation once the Route status is available
- `| trim` applied in the configmap template to guard against whitespace from Jinja2 folded scalars
- Molecule test verifies the ConfigMap contains both the Lightspeed and gateway origins

## Jira
- [AAP-76952](https://redhat.atlassian.net/browse/AAP-76952)
- Related: [AAP-61711](https://redhat.atlassian.net/browse/AAP-61711)

## Validation

### 1. kind cluster (before/after proof)

Tested end-to-end on a local kind cluster with `make run`, using `/admin/login/` as a CSRF-protected endpoint.

#### Before (main branch — no `CSRF_TRUSTED_ORIGINS` set)

ConfigMap has no `CSRF_TRUSTED_ORIGINS` entry. Django falls back to `["http://localhost:8000"]`.

| Origin | HTTP | Result |
|--------|------|--------|
| `https://lightspeed.example.com` (legitimate) | 403 | **CSRF REJECTED** — the bug |
| `https://evil-attacker.com` (attacker) | 403 | CSRF REJECTED |
| `http://localhost:8000` (Django default) | 200 | CSRF PASSED — only localhost works |

#### After (feature branch — `CSRF_TRUSTED_ORIGINS=https://lightspeed.example.com`)

ConfigMap contains `CSRF_TRUSTED_ORIGINS: "https://lightspeed.example.com"`.

| Origin | HTTP | Result |
|--------|------|--------|
| `https://lightspeed.example.com` (legitimate) | 200 | **CSRF PASSED — fix works** |
| `https://evil-attacker.com` (attacker) | 403 | CSRF REJECTED |
| `http://localhost:8000` (Django default) | 403 | CSRF REJECTED |

### 2. CRC / OpenShift Local with AAP 2.6 (real environment)

Tested on CRC with a full AAP 2.6 deployment (gateway, controller). The operator auto-discovered the Route host and extracted the gateway origin from the auth secret.

ConfigMap contains `CSRF_TRUSTED_ORIGINS: "https://aap-test-lightspeed-aap26.apps-crc.testing,https://myaap-aap26.apps-crc.testing"`

| Origin | HTTP | Result |
|--------|------|--------|
| `https://aap-test-lightspeed-aap26.apps-crc.testing` (Lightspeed Route) | 200 | **CSRF PASSED** |
| `https://myaap-aap26.apps-crc.testing` (AAP Gateway) | 200 | **CSRF PASSED** |
| `https://evil-attacker.com` (attacker) | 403 | **CSRF REJECTED** |

### Notes
- On the first reconciliation the Route origin is not yet available (Route hasn't been admitted); it is picked up on the second reconciliation — consistent with how `update_status.yml` handles Route URLs
- Pod rollout is automatic: the deployment template checksums the ConfigMap, so adding `CSRF_TRUSTED_ORIGINS` triggers a new rollout
- The kind cluster required `ANSIBLE_CONFIG=$(pwd)/ansible.cfg` to work around ~50 broken `when: x | length` conditionals in the codebase that fail on Ansible 2.20+ (pre-existing, unrelated to this PR)

## Test plan
- [x] Molecule test `10_0_csrf_trusted_origins_test.yml` passes
- [x] ConfigMap contains `CSRF_TRUSTED_ORIGINS` with Lightspeed origin and gateway origin
- [x] Ingress uses `http://` scheme when no TLS secret is configured
- [ ] `extra_settings` override takes precedence (no duplicate key)
- [x] Live CSRF validation: legitimate origin passes, attacker origin rejected
- [x] Tested on OpenShift Local (CRC) with AAP 2.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)