### PR TITLE
bump operator-sdk version to v1.42.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM quay.io/operator-framework/ansible-operator:v1.40.0
+FROM quay.io/operator-framework/ansible-operator:v1.42.2
 
 USER root
-RUN dnf update --disableplugin=subscription-manager --security --bugfix -y
+RUN microdnf update -y
 USER 1001
 
 ARG DEFAULT_AI_CONNECT_VERSION

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.40.0
+OPERATOR_SDK_VERSION ?= v1.42.2
 CONTAINER_TOOL ?= podman
 
 # Image URL to use all building/pushing image targets


### PR DESCRIPTION
## Description
Bump operator-sdk from v1.40.0 to v1.42.2. Updates `OPERATOR_SDK_VERSION` in Makefile and the base image in Dockerfile. Also updates Dockerfile to use `microdnf` in place of `dnf`, as the v1.42.2 base image does not include `dnf`.

## Testing
### Steps to test
1. Pull down the PR
2. Run `make operator-sdk` and verify v1.42.2 is downloaded
3. Run `make ansible-operator` and verify v1.42.2 is downloaded

### Scenarios tested
Verified Makefile and Dockerfile reference the correct version.

## Production deployment
- [x] This code change is ready for production on its own