### PR TITLE
mcp-server: add MCP_SERVER_URL env variable

### DIFF
--- a/molecule/default/tasks/6_2_mcpserver_url_test.yml
+++ b/molecule/default/tasks/6_2_mcpserver_url_test.yml
@@ -1,0 +1,22 @@
+---
+- block:
+    - name: Get MCP Server ConfigMap
+      kubernetes.core.k8s_info:
+        namespace: '{{ namespace }}'
+        kind: ConfigMap
+        name: ansiblemcpconnect-sample-ansible-mcp-connect-env-properties
+      register: mcpserver_configmap
+
+    - name: Assert MCP_SERVER_URL is set in ConfigMap
+      ansible.builtin.assert:
+        that:
+          - "'MCP_SERVER_URL' in mcpserver_configmap.resources[0].data"
+        fail_msg: ConfigMap does not contain MCP_SERVER_URL
+
+    - name: Assert MCP_SERVER_URL contains the expected origin
+      ansible.builtin.assert:
+        that:
+          - "mcpserver_configmap.resources[0].data.MCP_SERVER_URL == 'http://mcp.test.example.com'"
+        fail_msg: >-
+          MCP_SERVER_URL does not match expected value 'http://mcp.test.example.com',
+          got '{{ mcpserver_configmap.resources[0].data.MCP_SERVER_URL }}'

--- a/molecule/default/templates/create_mcpserver_instance.yaml.j2
+++ b/molecule/default/templates/create_mcpserver_instance.yaml.j2
@@ -16,6 +16,7 @@ spec:
   no_log: false
   ingress_type: Ingress
   ingress_path: /mcp
+  hostname: mcp.test.example.com
   service_type: NodePort
   image_pull_secrets:
     - redhat-operators-pull-secret

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -23,6 +23,7 @@
             # - tasks/5_0_optional_auth_config_test.yml
             - tasks/6_0_mcpserver_config_test.yml
             - tasks/6_1_mcpserver_backup_restore_test.yml
+            - tasks/6_2_mcpserver_url_test.yml
             - tasks/7_0_instance_version_test.yml
             - tasks/8_0_admin_user_test.yml
             - tasks/9_0_azure_openai_url_append_test.yml

--- a/roles/mcpserver/tasks/main.yml
+++ b/roles/mcpserver/tasks/main.yml
@@ -32,6 +32,9 @@
 - name: Configure installer ID
   ansible.builtin.include_tasks: installer_id_configuration.yml
 
+- name: Resolve MCP server URL
+  ansible.builtin.include_tasks: resolve_mcp_server_url.yml
+
 - name: Deploy MCP Server API service
   ansible.builtin.include_tasks: deploy_mcpserver_api.yml
 

--- a/roles/mcpserver/tasks/resolve_mcp_server_url.yml
+++ b/roles/mcpserver/tasks/resolve_mcp_server_url.yml
@@ -1,0 +1,26 @@
+---
+- name: Look up existing Route host
+  kubernetes.core.k8s_info:
+    api_version: '{{ route_api_version }}'
+    kind: Route
+    namespace: '{{ ansible_operator_meta.namespace }}'
+    name: '{{ ansible_operator_meta.name }}'
+  register: _existing_route
+  when: ingress_type | lower == 'route'
+
+- name: Set MCP server URL
+  ansible.builtin.set_fact:
+    _mcp_server_url: >-
+      {%- if ingress_type | lower == 'route' -%}
+        {%- if route_host | length -%}
+          https://{{ route_host }}
+        {%- elif _existing_route.resources | default([]) | length > 0
+                and _existing_route.resources[0].status is defined
+                and _existing_route.resources[0].status.ingress is defined
+                and _existing_route.resources[0].status.ingress | length > 0 -%}
+          https://{{ _existing_route.resources[0].status.ingress[0].host }}
+        {%- endif -%}
+      {%- elif ingress_type | lower == 'ingress' and hostname | length -%}
+        {%- set scheme = 'https' if ingress_tls_secret | length else 'http' -%}
+        {{ scheme }}://{{ hostname }}
+      {%- endif -%}

--- a/roles/mcpserver/templates/mcpserver.configmap.yaml.j2
+++ b/roles/mcpserver/templates/mcpserver.configmap.yaml.j2
@@ -9,6 +9,9 @@ metadata:
     {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(width=4) | trim }}
 data:
   BASE_URL: "{{ public_base_url }}"
+{% if _mcp_server_url | default('') | length %}
+  MCP_SERVER_URL: "{{ _mcp_server_url }}"
+{% endif %}
   INSTALLER_ID: "{{ __installer_id }}"
   INTERNAL_EMAIL_DOMAINS: "{{ internal_email_domains }}"
 {% if allow_write_operations is defined %}


### PR DESCRIPTION

<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://redhat.atlassian.net/browse/AAP-81863
<!-- This PR does not need a corresponding Jira item. -->

## Description
mcp-server: add MCP_SERVER_URL env variable

Assisted by Claude Code (opus 4.6)

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. start crc
3. clone https://github.com/shanemcd/crc-aap
4. run ansible-playbook deploy-aap.yml -e aap_hub_disabled=true -e aap_eda_disabled=true
5. make run
6. goto pod terminal 
7. run "echo $MCP_SERVER_URL"

### Scenarios tested
local crc testing deploying with make run
with instance 
```yaml
 mcpserver-instance.yaml
---
apiVersion: mcpconnect.ansible.com/v1alpha1
kind: AnsibleMCPConnect
metadata:
  name: aap-mcp-server
  namespace: aap26
spec:
  public_base_url: https://myaap-aap26.apps-crc.testing
  image_pull_secrets:
    - quay-pull-secret
```

<img width="702" height="354" alt="image" src="https://github.com/user-attachments/assets/490a6c5d-371b-4f04-9c46-8b7c41516272" />



## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This PR should be released in 2.4 (cherry-pick should be created)
- [ ] This PR should be released in 2.5 (cherry-pick should be created)
- [ ] This PR should be released in 2.6 (cherry-pick should be created)
- [X] This PR should be released in 2.7 (cherry-pick should be created)
- [ ] This code change requires the following considerations before going to production:
