### PR TITLE
fix: upgrade GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/code_quality.yaml
+++ b/.github/workflows/code_quality.yaml
@@ -23,7 +23,7 @@ jobs:
       pull-requests: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 

--- a/.github/workflows/common-build-and-publish-artifacts.yaml
+++ b/.github/workflows/common-build-and-publish-artifacts.yaml
@@ -36,7 +36,7 @@ jobs:
       # ===============================
       # Checkout code
       # -------------------------------
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -46,14 +46,14 @@ jobs:
       # Login to repositories
       # -------------------------------
       - name: Log into registry ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log into target registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_USER }}

--- a/.github/workflows/common-get-chatbot-version.yaml
+++ b/.github/workflows/common-get-chatbot-version.yaml
@@ -18,7 +18,7 @@ jobs:
       # ===============================
       # Checkout code
       # -------------------------------
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
       # ===============================

--- a/.github/workflows/common-get-mcpserver-version.yaml
+++ b/.github/workflows/common-get-mcpserver-version.yaml
@@ -18,7 +18,7 @@ jobs:
       # ===============================
       # Checkout code
       # -------------------------------
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
       # ===============================

--- a/.github/workflows/common-get-operator-versions.yaml
+++ b/.github/workflows/common-get-operator-versions.yaml
@@ -22,7 +22,7 @@ jobs:
       # ===============================
       # Checkout code to get tags
       # -------------------------------
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/common-get-service-version.yaml
+++ b/.github/workflows/common-get-service-version.yaml
@@ -18,7 +18,7 @@ jobs:
       # ===============================
       # Checkout code
       # -------------------------------
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
       # ===============================

--- a/.github/workflows/molecule-kind-tests.yaml
+++ b/.github/workflows/molecule-kind-tests.yaml
@@ -29,9 +29,9 @@ jobs:
       DOCKER_API_VERSION: "1.44"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/molecule-minikube-tests.yaml
+++ b/.github/workflows/molecule-minikube-tests.yaml
@@ -14,9 +14,9 @@ jobs:
       DOCKER_API_VERSION: "1.44"
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: '3.12'
 

--- a/.github/workflows/pr-build-and-publish-artifacts.yaml
+++ b/.github/workflows/pr-build-and-publish-artifacts.yaml
@@ -34,7 +34,7 @@ jobs:
       # ===============================
       # Checkout code
       # -------------------------------
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -44,14 +44,14 @@ jobs:
       # Login to repositories
       # -------------------------------
       - name: Log into registry ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log into target registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_USER }}


### PR DESCRIPTION
## Summary

- Upgrade `actions/checkout` from v3/v4 to v5.1.0 (Node.js 24 native support)
- Upgrade `docker/login-action` from v3 to v4.4.0 (Node.js 24 native support)
- Upgrade `actions/setup-python` from v4 to v5.6.0

All actions are pinned to full commit SHAs for supply chain security, with version comments for readability.

## Motivation

GitHub has deprecated Node.js 20 for Actions runners ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). CI builds now emit the following warning:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, docker/login-action@v3

This PR resolves those deprecation warnings by updating to action versions that natively target Node.js 24.

## Changes

| Action | Previous | Updated |
|--------|----------|---------|
| `actions/checkout` | v3 / v4 | v5.1.0 (`fbc6f39`) |
| `docker/login-action` | v3 | v4.4.0 (`af1e73f`) |
| `actions/setup-python` | v4 | v5.6.0 (`a26af69`) |

## Affected workflows

- `pr-build-and-publish-artifacts.yaml`
- `common-build-and-publish-artifacts.yaml`
- `code_quality.yaml`
- `common-get-service-version.yaml`
- `common-get-operator-versions.yaml`
- `common-get-chatbot-version.yaml`
- `common-get-mcpserver-version.yaml`
- `molecule-kind-tests.yaml`
- `molecule-minikube-tests.yaml`

## Test plan

- [ ] PR build workflow passes without Node.js 20 deprecation warnings
- [ ] Code quality workflow completes successfully
- [ ] Molecule tests (if triggered) work with updated actions


Made with [Cursor](https://cursor.com)