### PR TITLE
fix: augment NO_PROXY with required internal exclusions in proxy-env ConfigMap

### DIFF
--- a/roles/chatbot/tasks/main.yml
+++ b/roles/chatbot/tasks/main.yml
@@ -14,6 +14,20 @@
   - name: Read AnsibleAIConnect's Chatbot secret
     ansible.builtin.include_tasks: read_chatbot_configuration_secret.yml
 
+  - name: Set AAP service hostnames for NO_PROXY exclusion
+    ansible.builtin.set_fact:
+      _aap_gateway_hostname: "{{ _aap_gateway_url | default('') | urlsplit('hostname') }}"
+      _aap_controller_hostname: "{{ _aap_controller_url | default('') | urlsplit('hostname') }}"
+
+  - name: Re-apply proxy environment ConfigMap with AAP service hostnames
+    kubernetes.core.k8s:
+      apply: true
+      definition: "{{ lookup('template', '../../common/templates/proxy-env.configmap.yaml.j2') }}"
+      state: present
+    when:
+      - http_proxy or https_proxy or no_proxy
+      - _aap_gateway_hostname | default('') or _aap_controller_hostname | default('')
+
   - name: Read AnsibleAIConnect's Chatbot API Key
     ansible.builtin.include_tasks: handle_chatbot_api_key_secret.yml
 

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -31,6 +31,13 @@
 - name: Patch Labels
   ansible.builtin.include_tasks: patch_labels.yml
 
+- name: Set gateway hostname for NO_PROXY exclusion
+  ansible.builtin.set_fact:
+    _gateway_hostname: >-
+      {{ extra_settings | default([]) | selectattr('setting', 'equalto', 'ANSIBLE_BASE_JWT_KEY')
+         | map(attribute='value') | select | list | first | default('')
+         | urlsplit('hostname') }}
+
 - name: Apply proxy environment ConfigMap
   kubernetes.core.k8s:
     apply: yes

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -34,8 +34,8 @@
 - name: Set gateway hostname for NO_PROXY exclusion
   ansible.builtin.set_fact:
     _gateway_hostname: >-
-      {{ extra_settings | default([]) | selectattr('setting', 'equalto', 'ANSIBLE_BASE_JWT_KEY')
-         | map(attribute='value') | select | list | first | default('')
+      {{ (extra_settings | default([]) | selectattr('setting', 'equalto', 'ANSIBLE_BASE_JWT_KEY')
+         | map(attribute='value') | select | list | first | default(public_base_url | default('')))
          | urlsplit('hostname') }}
 
 - name: Apply proxy environment ConfigMap

--- a/roles/common/templates/proxy-env.configmap.yaml.j2
+++ b/roles/common/templates/proxy-env.configmap.yaml.j2
@@ -15,7 +15,7 @@ data:
 {% endif %}
 {% if http_proxy or https_proxy or no_proxy %}
 {% set _no_proxy_list = (no_proxy | default('')).split(',') | map('trim') | select | list %}
-{% set _required = ['localhost', '127.0.0.1', '::1', '[::1]', '.svc', '.svc.cluster.local', ansible_operator_meta.name, ansible_operator_meta.name + '.' + ansible_operator_meta.namespace, ansible_operator_meta.name + '-api', ansible_operator_meta.name + '-api.' + ansible_operator_meta.namespace] %}
+{% set _required = ['localhost', '127.0.0.1', '::1', '.svc', '.svc.cluster.local', ansible_operator_meta.name, ansible_operator_meta.name + '.' + ansible_operator_meta.namespace, ansible_operator_meta.name + '-api', ansible_operator_meta.name + '-api.' + ansible_operator_meta.namespace] %}
 {% if _gateway_hostname | default('') %}
 {% set _required = (_required + [_gateway_hostname, _gateway_hostname + '.' + ansible_operator_meta.namespace]) | unique %}
 {% endif %}

--- a/roles/common/templates/proxy-env.configmap.yaml.j2
+++ b/roles/common/templates/proxy-env.configmap.yaml.j2
@@ -13,7 +13,10 @@ data:
   HTTPS_PROXY: '{{ https_proxy }}'
   https_proxy: '{{ https_proxy }}'
 {% endif %}
-{% if no_proxy %}
-  NO_PROXY: '{{ no_proxy }}'
-  no_proxy: '{{ no_proxy }}'
+{% if http_proxy or https_proxy or no_proxy %}
+{% set _no_proxy_list = (no_proxy | default('')).split(',') | map('trim') | select | list %}
+{% set _required = ['localhost', '127.0.0.1', '::1', '[::1]', '.svc', '.svc.cluster.local', ansible_operator_meta.name, ansible_operator_meta.name + '.' + ansible_operator_meta.namespace, ansible_operator_meta.name + '-api', ansible_operator_meta.name + '-api.' + ansible_operator_meta.namespace] %}
+{% set _augmented = (_no_proxy_list + _required) | unique | join(',') %}
+  NO_PROXY: {{ _augmented | to_yaml }}
+  no_proxy: {{ _augmented | to_yaml }}
 {% endif %}

--- a/roles/common/templates/proxy-env.configmap.yaml.j2
+++ b/roles/common/templates/proxy-env.configmap.yaml.j2
@@ -16,7 +16,16 @@ data:
 {% if http_proxy or https_proxy or no_proxy %}
 {% set _no_proxy_list = (no_proxy | default('')).split(',') | map('trim') | select | list %}
 {% set _required = ['localhost', '127.0.0.1', '::1', '[::1]', '.svc', '.svc.cluster.local', ansible_operator_meta.name, ansible_operator_meta.name + '.' + ansible_operator_meta.namespace, ansible_operator_meta.name + '-api', ansible_operator_meta.name + '-api.' + ansible_operator_meta.namespace] %}
+{% if _gateway_hostname | default('') %}
+{% set _required = (_required + [_gateway_hostname, _gateway_hostname + '.' + ansible_operator_meta.namespace]) | unique %}
+{% endif %}
+{% if _aap_gateway_hostname | default('') %}
+{% set _required = (_required + [_aap_gateway_hostname, _aap_gateway_hostname + '.' + ansible_operator_meta.namespace]) | unique %}
+{% endif %}
+{% if _aap_controller_hostname | default('') %}
+{% set _required = (_required + [_aap_controller_hostname, _aap_controller_hostname + '.' + ansible_operator_meta.namespace]) | unique %}
+{% endif %}
 {% set _augmented = (_no_proxy_list + _required) | unique | join(',') %}
-  NO_PROXY: {{ _augmented | to_yaml }}
-  no_proxy: {{ _augmented | to_yaml }}
+  NO_PROXY: '{{ _augmented }}'
+  no_proxy: '{{ _augmented }}'
 {% endif %}


### PR DESCRIPTION
## Summary

When a cluster-wide egress proxy is configured on OpenShift, the operator propagates `NO_PROXY` verbatim from the operator pod environment into the `proxy-env` ConfigMap that is mounted via `envFrom` into operand containers. OCP's default `NO_PROXY` uses `.svc` and `.svc.cluster.local` suffix patterns, which do not match the bare short service names operators use for internal communication (e.g. `http://<cr-name>`). This causes internal traffic — including JWT key validation calls — to route through the corporate proxy instead of staying in-cluster, producing authentication failures and component unavailability.

This fix augments `NO_PROXY` before writing it to the ConfigMap:
- Customer-provided entries are preserved first, in their original order
- Required internal exclusions are appended if not already present: `localhost`, `127.0.0.1`, `::1`, `[::1]`, `.svc`, `.svc.cluster.local`, the CR short name, and the namespaced CR name
- `NO_PROXY` is now emitted whenever any proxy variable is set, not only when `NO_PROXY` itself is non-empty
- The `unique` filter ensures deterministic ordering across reconciliation loops (prevents spurious pod restarts from changing ConfigMap checksums)

## Related

- AAP-83822 — Jira tracking issue for this fix across all operators
- AAP-83727 — Sev1 customer escalation (JWT 401 errors on proxy-configured OCP clusters)
- aap-gateway-operator MR !1011 — same fix applied to the gateway operator first
- KCS workaround: https://access.redhat.com/solutions/7145692

## Test Plan

- [ ] Deploy operator on an OCP cluster with a cluster-wide egress proxy configured
- [ ] Confirm `<cr-name>-proxy-env` ConfigMap is created and `NO_PROXY` value contains all required internal exclusions
- [ ] Confirm customer-provided `NO_PROXY` entries are preserved
- [ ] Confirm no regression on clusters without a proxy configured (ConfigMap absent when no proxy vars set)
- [ ] Confirm `NO_PROXY` value is byte-for-byte identical across consecutive reconciliation loops