### PR TITLE
chore: remove stale chatbot PVC cleanup task

### DIFF
--- a/roles/chatbot/tasks/remove_chatbot_api.yml
+++ b/roles/chatbot/tasks/remove_chatbot_api.yml
@@ -46,10 +46,3 @@
     name: '{{ ansible_operator_meta.name }}-chatbot-api'
     namespace: '{{ ansible_operator_meta.namespace }}'
     wait: yes
-
-- name: Remove Chatbot PVC
-  kubernetes.core.k8s:
-    state: absent
-    kind: PersistentVolumeClaim
-    name: "{{ ansible_operator_meta.name }}-chatbot-pvc"
-    namespace: "{{ ansible_operator_meta.namespace }}"


### PR DESCRIPTION
## Summary

Remove the `Remove Chatbot PVC` task from `roles/chatbot/tasks/remove_chatbot_api.yml`.

## Context

The PVC for the Chatbot was removed in [AAP-54538](https://redhat.atlassian.net/browse/AAP-54538). A cleanup task was left in the removal playbook to ensure existing users' namespaces were tidied up during chatbot uninstallation.

Sufficient time has passed and it is safe to assume all users have cleared the `chatbot-pvc`. This removes the dead code.

**Accepted risk:** If someone installed early 2.6 builds, never updated to latest 2.6, and upgrades directly to 2.8+, an orphaned PVC could remain. This is considered low-probability and harmless (only wastes minor storage).

Relates: [AAP-55086](https://redhat.atlassian.net/browse/AAP-55086)

Made with [Cursor](https://cursor.com)