### PR TITLE
feat: add HTTP health probes for chatbot

### DIFF
--- a/roles/chatbot/templates/chatbot.configmap_lightspeed_stack_config.yaml.j2
+++ b/roles/chatbot/templates/chatbot.configmap_lightspeed_stack_config.yaml.j2
@@ -47,6 +47,7 @@ data:
 {% endif %}
     authentication:
       module: "api-key-token"
+      skip_for_health_probes: true
       api_key_config:
         api_key: ${env.CHATBOT_API_KEY}
 {% if _aap_gateway_url is defined or _aap_controller_url is defined %}

--- a/roles/chatbot/templates/chatbot.deployment.yaml.j2
+++ b/roles/chatbot/templates/chatbot.deployment.yaml.j2
@@ -169,25 +169,44 @@ spec:
           - containerPort: 8080
 {% endif %}
             protocol: TCP
-        readinessProbe:
-          tcpSocket:
+        startupProbe:
+          httpGet:
+            path: /liveness
 {% if is_openshift %}
             port: 8443
+            scheme: HTTPS
 {% else %}
             port: 8080
+            scheme: HTTP
 {% endif %}
-          initialDelaySeconds: 15
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          failureThreshold: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /readiness
+{% if is_openshift %}
+            port: 8443
+            scheme: HTTPS
+{% else %}
+            port: 8080
+            scheme: HTTP
+{% endif %}
+          initialDelaySeconds: 5
           periodSeconds: 10
           failureThreshold: 3
-          timeoutSeconds: 5
+          timeoutSeconds: 10
         livenessProbe:
-          tcpSocket:
+          httpGet:
+            path: /liveness
 {% if is_openshift %}
             port: 8443
+            scheme: HTTPS
 {% else %}
             port: 8080
+            scheme: HTTP
 {% endif %}
-          initialDelaySeconds: 30
           periodSeconds: 10
           failureThreshold: 5
           timeoutSeconds: 5

--- a/roles/chatbot/templates/chatbot.deployment.yaml.j2
+++ b/roles/chatbot/templates/chatbot.deployment.yaml.j2
@@ -254,7 +254,6 @@ spec:
         ports:
           - containerPort: 8004
             protocol: TCP
-        # No HTTP health endpoint in ansible-mcp-controller; TCP is the best available check.
         readinessProbe:
           tcpSocket:
             port: 8004
@@ -313,7 +312,6 @@ spec:
         ports:
           - containerPort: 8005
             protocol: TCP
-        # No HTTP health endpoint in ansible-mcp-lightspeed; TCP is the best available check.
         readinessProbe:
           tcpSocket:
             port: 8005

--- a/roles/chatbot/templates/chatbot.deployment.yaml.j2
+++ b/roles/chatbot/templates/chatbot.deployment.yaml.j2
@@ -169,6 +169,58 @@ spec:
           - containerPort: 8080
 {% endif %}
             protocol: TCP
+{#
+  /liveness and /readiness require Bearer API-key auth (api-key-token).
+  httpGet cannot supply that secret safely, and api-key-token does not honor
+  skip_for_health_probes, so use an exec probe that reads CHATBOT_API_KEY.
+#}
+        startupProbe:
+          exec:
+            command:
+              - /bin/sh
+              - -c
+{% if is_openshift %}
+              - >-
+                $PYTHON -c 'import os,ssl,urllib.request; urllib.request.urlopen(urllib.request.Request("https://127.0.0.1:8443/liveness", headers={"Authorization": "Bearer " + os.environ["CHATBOT_API_KEY"]}), context=ssl._create_unverified_context())'
+{% else %}
+              - >-
+                $PYTHON -c 'import os,urllib.request; urllib.request.urlopen(urllib.request.Request("http://127.0.0.1:8080/liveness", headers={"Authorization": "Bearer " + os.environ["CHATBOT_API_KEY"]}))'
+{% endif %}
+          failureThreshold: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+              - /bin/sh
+              - -c
+{% if is_openshift %}
+              - >-
+                $PYTHON -c 'import os,ssl,urllib.request; urllib.request.urlopen(urllib.request.Request("https://127.0.0.1:8443/readiness", headers={"Authorization": "Bearer " + os.environ["CHATBOT_API_KEY"]}), context=ssl._create_unverified_context())'
+{% else %}
+              - >-
+                $PYTHON -c 'import os,urllib.request; urllib.request.urlopen(urllib.request.Request("http://127.0.0.1:8080/readiness", headers={"Authorization": "Bearer " + os.environ["CHATBOT_API_KEY"]}))'
+{% endif %}
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          failureThreshold: 3
+          timeoutSeconds: 5
+        livenessProbe:
+          exec:
+            command:
+              - /bin/sh
+              - -c
+{% if is_openshift %}
+              - >-
+                $PYTHON -c 'import os,ssl,urllib.request; urllib.request.urlopen(urllib.request.Request("https://127.0.0.1:8443/liveness", headers={"Authorization": "Bearer " + os.environ["CHATBOT_API_KEY"]}), context=ssl._create_unverified_context())'
+{% else %}
+              - >-
+                $PYTHON -c 'import os,urllib.request; urllib.request.urlopen(urllib.request.Request("http://127.0.0.1:8080/liveness", headers={"Authorization": "Bearer " + os.environ["CHATBOT_API_KEY"]}))'
+{% endif %}
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          failureThreshold: 5
+          timeoutSeconds: 5
         volumeMounts:
           - name: ansible-chatbot-storage
             mountPath: /.llama/data
@@ -232,6 +284,21 @@ spec:
         ports:
           - containerPort: 8004
             protocol: TCP
+        # No HTTP health endpoint in ansible-mcp-controller; TCP is the best available check.
+        readinessProbe:
+          tcpSocket:
+            port: 8004
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          failureThreshold: 3
+          timeoutSeconds: 5
+        livenessProbe:
+          tcpSocket:
+            port: 8004
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          failureThreshold: 5
+          timeoutSeconds: 5
         securityContext:
           runAsNonRoot: true
           allowPrivilegeEscalation: false
@@ -276,6 +343,21 @@ spec:
         ports:
           - containerPort: 8005
             protocol: TCP
+        # No HTTP health endpoint in ansible-mcp-lightspeed; TCP is the best available check.
+        readinessProbe:
+          tcpSocket:
+            port: 8005
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          failureThreshold: 3
+          timeoutSeconds: 5
+        livenessProbe:
+          tcpSocket:
+            port: 8005
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          failureThreshold: 5
+          timeoutSeconds: 5
         securityContext:
           runAsNonRoot: true
           allowPrivilegeEscalation: false

--- a/roles/chatbot/templates/chatbot.deployment.yaml.j2
+++ b/roles/chatbot/templates/chatbot.deployment.yaml.j2
@@ -169,53 +169,23 @@ spec:
           - containerPort: 8080
 {% endif %}
             protocol: TCP
-{#
-  /liveness and /readiness require Bearer API-key auth (api-key-token).
-  httpGet cannot supply that secret safely, and api-key-token does not honor
-  skip_for_health_probes, so use an exec probe that reads CHATBOT_API_KEY.
-#}
-        startupProbe:
-          exec:
-            command:
-              - /bin/sh
-              - -c
-{% if is_openshift %}
-              - >-
-                $PYTHON -c 'import os,ssl,urllib.request; urllib.request.urlopen(urllib.request.Request("https://127.0.0.1:8443/liveness", headers={"Authorization": "Bearer " + os.environ["CHATBOT_API_KEY"]}), context=ssl._create_unverified_context())'
-{% else %}
-              - >-
-                $PYTHON -c 'import os,urllib.request; urllib.request.urlopen(urllib.request.Request("http://127.0.0.1:8080/liveness", headers={"Authorization": "Bearer " + os.environ["CHATBOT_API_KEY"]}))'
-{% endif %}
-          failureThreshold: 30
-          periodSeconds: 10
-          timeoutSeconds: 5
         readinessProbe:
-          exec:
-            command:
-              - /bin/sh
-              - -c
+          tcpSocket:
 {% if is_openshift %}
-              - >-
-                $PYTHON -c 'import os,ssl,urllib.request; urllib.request.urlopen(urllib.request.Request("https://127.0.0.1:8443/readiness", headers={"Authorization": "Bearer " + os.environ["CHATBOT_API_KEY"]}), context=ssl._create_unverified_context())'
+            port: 8443
 {% else %}
-              - >-
-                $PYTHON -c 'import os,urllib.request; urllib.request.urlopen(urllib.request.Request("http://127.0.0.1:8080/readiness", headers={"Authorization": "Bearer " + os.environ["CHATBOT_API_KEY"]}))'
+            port: 8080
 {% endif %}
           initialDelaySeconds: 15
           periodSeconds: 10
           failureThreshold: 3
           timeoutSeconds: 5
         livenessProbe:
-          exec:
-            command:
-              - /bin/sh
-              - -c
+          tcpSocket:
 {% if is_openshift %}
-              - >-
-                $PYTHON -c 'import os,ssl,urllib.request; urllib.request.urlopen(urllib.request.Request("https://127.0.0.1:8443/liveness", headers={"Authorization": "Bearer " + os.environ["CHATBOT_API_KEY"]}), context=ssl._create_unverified_context())'
+            port: 8443
 {% else %}
-              - >-
-                $PYTHON -c 'import os,urllib.request; urllib.request.urlopen(urllib.request.Request("http://127.0.0.1:8080/liveness", headers={"Authorization": "Bearer " + os.environ["CHATBOT_API_KEY"]}))'
+            port: 8080
 {% endif %}
           initialDelaySeconds: 30
           periodSeconds: 10

--- a/roles/mcpserver/templates/mcpserver.deployment.yaml.j2
+++ b/roles/mcpserver/templates/mcpserver.deployment.yaml.j2
@@ -156,15 +156,21 @@ spec:
         - containerPort: {{ default_http_port }}
           protocol: TCP
         readinessProbe:
-          tcpSocket:
+          httpGet:
+            path: /api/v1/health
             port: {{ default_http_port }}
           initialDelaySeconds: 15
           periodSeconds: 10
+          failureThreshold: 3
+          timeoutSeconds: 5
         livenessProbe:
-          tcpSocket:
+          httpGet:
+            path: /api/v1/health
             port: {{ default_http_port }}
           initialDelaySeconds: 15
           periodSeconds: 10
+          failureThreshold: 5
+          timeoutSeconds: 5
         volumeMounts:
 {% if bundle_ca_crt or is_openshift %}
             - name: combined-ca-bundle

--- a/roles/mcpserver/templates/mcpserver.deployment.yaml.j2
+++ b/roles/mcpserver/templates/mcpserver.deployment.yaml.j2
@@ -156,21 +156,15 @@ spec:
         - containerPort: {{ default_http_port }}
           protocol: TCP
         readinessProbe:
-          httpGet:
-            path: /api/v1/health
+          tcpSocket:
             port: {{ default_http_port }}
           initialDelaySeconds: 15
           periodSeconds: 10
-          failureThreshold: 3
-          timeoutSeconds: 5
         livenessProbe:
-          httpGet:
-            path: /api/v1/health
+          tcpSocket:
             port: {{ default_http_port }}
           initialDelaySeconds: 15
           periodSeconds: 10
-          failureThreshold: 5
-          timeoutSeconds: 5
         volumeMounts:
 {% if bundle_ca_crt or is_openshift %}
             - name: combined-ca-bundle


### PR DESCRIPTION
## Summary
- Add HTTP readiness/liveness probes for `ansible-chatbot` against `/readiness` and `/liveness`
- Add a `startupProbe` on `/liveness` so slow startup (model/LLM init) is not killed by liveness too early (~160s budget)
- Enable `skip_for_health_probes: true` in the Lightspeed Stack config so unauthenticated kubelet probes work with `api-key-token`
- Keep TCP probes for MCP controller/lightspeed sidecars (no HTTP health endpoints)

Addresses [AAP-29470](https://redhat.atlassian.net/browse/AAP-29470).

### Clarification vs Docker `--restart=on-failure:5`
This does **not** cap total container restarts at 5. `livenessProbe.failureThreshold: 5` means “restart after 5 consecutive failed probe checks.” Deployments still restart indefinitely; Kubernetes’ CrashLoopBackOff exponential backoff is the platform-native equivalent of limiting restart pressure. That is appropriate for long-running services. The Jira description should be updated to reflect this difference from Docker.

### Probe details (`ansible-chatbot`)
| Probe | Path | Notes |
|---|---|---|
| `startupProbe` | `/liveness` | `failureThreshold: 30`, `periodSeconds: 5` |
| `readinessProbe` | `/readiness` | `timeoutSeconds: 10` (LLM connectivity check can be slow) |
| `livenessProbe` | `/liveness` | `failureThreshold: 5` |

OpenShift uses `HTTPS:8443`; plain Kubernetes uses `HTTP:8080`.

### Dependency
`skip_for_health_probes` for `api-key-token` is supported in current lightspeed-stack main. Chatbot images based on older lightspeed-stack builds that lack this support would 401 on these probes.

## Test plan
- [ ] Deploy AnsibleAIConnect with chatbot enabled; confirm pod becomes Ready
- [ ] `kubectl describe pod` shows HTTP startup/readiness/liveness on `ansible-chatbot`
- [ ] Confirm MCP sidecars (when present) still use TCP probes on 8004/8005
- [ ] Verify OpenShift uses HTTPS:8443 and Kubernetes uses HTTP:8080
- [ ] Confirm readiness can tolerate a slow LLM check (`timeoutSeconds: 10`)
- [ ] Confirm slow startup does not get killed before `startupProbe` completes