### PR TITLE
revert: remove HTTP health probes for chatbot (#776)

### DIFF
--- a/roles/chatbot/templates/chatbot.configmap_lightspeed_stack_config.yaml.j2
+++ b/roles/chatbot/templates/chatbot.configmap_lightspeed_stack_config.yaml.j2
@@ -47,7 +47,6 @@ data:
 {% endif %}
     authentication:
       module: "api-key-token"
-      skip_for_health_probes: true
       api_key_config:
         api_key: ${env.CHATBOT_API_KEY}
 {% if _aap_gateway_url is defined or _aap_controller_url is defined %}

--- a/roles/chatbot/templates/chatbot.deployment.yaml.j2
+++ b/roles/chatbot/templates/chatbot.deployment.yaml.j2
@@ -169,47 +169,6 @@ spec:
           - containerPort: 8080
 {% endif %}
             protocol: TCP
-        startupProbe:
-          httpGet:
-            path: /liveness
-{% if is_openshift %}
-            port: 8443
-            scheme: HTTPS
-{% else %}
-            port: 8080
-            scheme: HTTP
-{% endif %}
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          failureThreshold: 30
-          timeoutSeconds: 5
-        readinessProbe:
-          httpGet:
-            path: /readiness
-{% if is_openshift %}
-            port: 8443
-            scheme: HTTPS
-{% else %}
-            port: 8080
-            scheme: HTTP
-{% endif %}
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          failureThreshold: 3
-          timeoutSeconds: 10
-        livenessProbe:
-          httpGet:
-            path: /liveness
-{% if is_openshift %}
-            port: 8443
-            scheme: HTTPS
-{% else %}
-            port: 8080
-            scheme: HTTP
-{% endif %}
-          periodSeconds: 10
-          failureThreshold: 5
-          timeoutSeconds: 5
         volumeMounts:
           - name: ansible-chatbot-storage
             mountPath: /.llama/data
@@ -273,20 +232,6 @@ spec:
         ports:
           - containerPort: 8004
             protocol: TCP
-        readinessProbe:
-          tcpSocket:
-            port: 8004
-          initialDelaySeconds: 15
-          periodSeconds: 10
-          failureThreshold: 3
-          timeoutSeconds: 5
-        livenessProbe:
-          tcpSocket:
-            port: 8004
-          initialDelaySeconds: 15
-          periodSeconds: 10
-          failureThreshold: 5
-          timeoutSeconds: 5
         securityContext:
           runAsNonRoot: true
           allowPrivilegeEscalation: false
@@ -331,20 +276,6 @@ spec:
         ports:
           - containerPort: 8005
             protocol: TCP
-        readinessProbe:
-          tcpSocket:
-            port: 8005
-          initialDelaySeconds: 15
-          periodSeconds: 10
-          failureThreshold: 3
-          timeoutSeconds: 5
-        livenessProbe:
-          tcpSocket:
-            port: 8005
-          initialDelaySeconds: 15
-          periodSeconds: 10
-          failureThreshold: 5
-          timeoutSeconds: 5
         securityContext:
           runAsNonRoot: true
           allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
- Reverts #776 (`774d5f7`) which added HTTP `/liveness`/`/readiness` probes and `skip_for_health_probes: true` for the chatbot.
- Current chatbot images are still on lightspeed-stack **0.4.3.1**, where `api-key-token` does **not** honor `skip_for_health_probes` (that support lands in newer stack, ~0.6.0rc2+).
- Unauthenticated probe calls return **401**, so HTTP liveness would CrashLoop chatbot pods once this operator is deployed against current images.

## Test plan
- [x] Confirmed on OpenShift `katuli-test`: `GET /liveness` and `/readiness` without auth → 401
- [x] Confirmed still 401 after enabling `skip_for_health_probes: true` and restarting
- [x] Confirmed running image `api_key_token.py` has no skip helper
- [ ] CI green on this revert PR
- [ ] Re-introduce HTTP probes only after chatbot/stack includes api-key skip support (or use TCP probes as an interim)

Fixes follow-up for AAP-29470 compatibility gap.


Made with [Cursor](https://cursor.com)