### PR TITLE
feat: add health probes for chatbot and MCP sidecar containers

### DIFF
--- a/roles/chatbot/templates/chatbot.deployment.yaml.j2
+++ b/roles/chatbot/templates/chatbot.deployment.yaml.j2
@@ -169,6 +169,47 @@ spec:
           - containerPort: 8080
 {% endif %}
             protocol: TCP
+        startupProbe:
+          exec:
+            command:
+              - sh
+              - -c
+{% if is_openshift %}
+              - "curl -sk -o /dev/null -w '%{http_code}' https://localhost:8443/liveness | grep -qE '^(200|401)$'"
+{% else %}
+              - "curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/liveness | grep -qE '^(200|401)$'"
+{% endif %}
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          failureThreshold: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+              - sh
+              - -c
+{% if is_openshift %}
+              - "curl -sk -o /dev/null -w '%{http_code}' https://localhost:8443/readiness | grep -qE '^(200|401)$'"
+{% else %}
+              - "curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/readiness | grep -qE '^(200|401)$'"
+{% endif %}
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          failureThreshold: 3
+          timeoutSeconds: 10
+        livenessProbe:
+          exec:
+            command:
+              - sh
+              - -c
+{% if is_openshift %}
+              - "curl -sk -o /dev/null -w '%{http_code}' https://localhost:8443/liveness | grep -qE '^(200|401)$'"
+{% else %}
+              - "curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/liveness | grep -qE '^(200|401)$'"
+{% endif %}
+          periodSeconds: 10
+          failureThreshold: 5
+          timeoutSeconds: 5
         volumeMounts:
           - name: ansible-chatbot-storage
             mountPath: /.llama/data
@@ -232,6 +273,20 @@ spec:
         ports:
           - containerPort: 8004
             protocol: TCP
+        readinessProbe:
+          tcpSocket:
+            port: 8004
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          failureThreshold: 3
+          timeoutSeconds: 5
+        livenessProbe:
+          tcpSocket:
+            port: 8004
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          failureThreshold: 5
+          timeoutSeconds: 5
         securityContext:
           runAsNonRoot: true
           allowPrivilegeEscalation: false
@@ -276,6 +331,20 @@ spec:
         ports:
           - containerPort: 8005
             protocol: TCP
+        readinessProbe:
+          tcpSocket:
+            port: 8005
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          failureThreshold: 3
+          timeoutSeconds: 5
+        livenessProbe:
+          tcpSocket:
+            port: 8005
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          failureThreshold: 5
+          timeoutSeconds: 5
         securityContext:
           runAsNonRoot: true
           allowPrivilegeEscalation: false


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://redhat.atlassian.net/browse/AAP-29470
<!-- This PR does not need a corresponding Jira item. -->

## Description
Use exec probes with curl for the chatbot container, accepting both HTTP 200 and 401 as healthy (401 confirms the app is serving but requires auth — the current lightspeed-stack 0.4.3.1 does not support skip_for_health_probes). MCP sidecars use TCP socket probes.

- startupProbe: /liveness (allow ~160s slow startup)
- readinessProbe: /readiness (timeoutSeconds: 10 for LLM check)
- livenessProbe: /liveness (failureThreshold: 5)
- MCP sidecars: TCP on ports 8004/8005

Verified curl is available in the chatbot container and endpoints respond as expected:
```
  $ curl -sk -o /dev/null -w '%{http_code}' https://localhost:8443/liveness
  401
  $ curl -sk -o /dev/null -w '%{http_code}' https://localhost:8443/readiness
  401
```

Issue: https://redhat.atlassian.net/browse/AAP-29470
## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Deploy lightspeed instance on local crc with enabled mcp_tools
2. Run 
```command
oc get pods -n <NS> -l app.kubernetes.io/component=ansible-ai-connect-chatbot-api
NAME                                               READY   STATUS    RESTARTS   AGE
aap-test-lightspeed-chatbot-api-7f587df74f-l948n   3/3     Running   0          10m
```
should receive running status 3 of 3/3 containers 
3. Run 
```command
oc describe -n <NS> pod -l app.kubernetes.io/component=ansible-ai-connect-chatbot-api | grep -A5 -E "Liveness|Readiness|Startup"
```
should show how much failed status and having success status on startup
```text
    Liveness:   exec [sh -c curl -sk -o /dev/null -w '%{http_code}' https://localhost:8443/liveness | grep -qE '^(200|401)$'] delay=0s timeout=5s period=10s #success=1 #failure=5
    Readiness:  exec [sh -c curl -sk -o /dev/null -w '%{http_code}' https://localhost:8443/readiness | grep -qE '^(200|401)$'] delay=5s timeout=10s period=10s #success=1 #failure=3
    Startup:    exec [sh -c curl -sk -o /dev/null -w '%{http_code}' https://localhost:8443/liveness | grep -qE '^(200|401)$'] delay=10s timeout=5s period=5s #success=1 #failure=30
    Environment Variables from:
      aap-test-lightspeed-proxy-env  ConfigMap  Optional: true
    Environment:
      LLAMA_STACK_CONFIG_DIR:  /.llama/data
      EMBEDDING_MODEL:         ./embeddings_model
--
    Liveness:        tcp-socket :8004 delay=15s timeout=5s period=10s #success=1 #failure=5
    Readiness:       tcp-socket :8004 delay=15s timeout=5s period=10s #success=1 #failure=3
    Environment Variables from:
      aap-test-lightspeed-proxy-env  ConfigMap  Optional: true
    Environment:
      HOST:             
      PORT:             8004
--
    Liveness:        tcp-socket :8005 delay=15s timeout=5s period=10s #success=1 #failure=5
    Readiness:       tcp-socket :8005 delay=15s timeout=5s period=10s #success=1 #failure=3
    Environment Variables from:
      aap-test-lightspeed-proxy-env  ConfigMap  Optional: true
    Environment:
      HOST:             
      PORT:             8005
--
  Warning  Unhealthy       11m (x2 over 11m)  kubelet            Startup probe failed:
  Warning  Unhealthy       11m                kubelet            Liveness probe failed: dial tcp 10.217.0.95:8004: connect: connection refused
  Warning  Unhealthy       10m (x3 over 11m)  kubelet            Readiness probe failed: dial tcp 10.217.0.95:8004: connect: connection refused
```

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [ ] This code change is ready for production on its own
- [ ] This PR should be released in 2.4 (cherry-pick should be created)
- [ ] This PR should be released in 2.5 (cherry-pick should be created)
- [ ] This PR should be released in 2.6 (cherry-pick should be created)
- [ ] This code change requires the following considerations before going to production:
